### PR TITLE
Add rs-server-libraries repository as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rs-server-libraries"]
+	path = rs-server-libraries
+	url = https://github.com/RS-PYTHON/rs-server-libraries.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rs-server-libraries"]
-	path = rs-server-libraries
+	path = libraries
 	url = https://github.com/RS-PYTHON/rs-server-libraries.git


### PR DESCRIPTION
This implements the user story 126 which requests to add the rs-server-libraries repository as a submodule