### PR TITLE
Change search sorting order

### DIFF
--- a/services/adgs/rs_server_adgs/api/adgs_search.py
+++ b/services/adgs/rs_server_adgs/api/adgs_search.py
@@ -32,7 +32,7 @@ ADGS_CONFIG = Path(osp.realpath(osp.dirname(__file__))).parent.parent / "config"
 async def search_products(
     datetime: Annotated[str, Query(description="Time interval e.g. '2024-01-01T00:00:00Z/2024-01-02T23:59:59Z'")],
     limit: Annotated[int, Query(description="Maximum number of products to return")] = 1000,
-    sortby: Annotated[str, Query(description="Sort by +/-fieldName (ascending/descending)")] = "+doNotSort",
+    sortby: Annotated[str, Query(description="Sort by +/-fieldName (ascending/descending)")] = "-datetime",
 ) -> list[dict] | dict:  # pylint: disable=too-many-locals
     """Endpoint to handle the search for products in the AUX station within a specified time interval.
 

--- a/services/cadip/rs_server_cadip/api/cadip_search.py
+++ b/services/cadip/rs_server_cadip/api/cadip_search.py
@@ -35,7 +35,7 @@ async def search_products(
     datetime: Annotated[str, Query(description="Time interval e.g. '2024-01-01T00:00:00Z/2024-01-02T23:59:59Z'")],
     station: str = FPath(description="CADIP station identifier (MTI, SGS, MPU, INU, etc)"),
     limit: Annotated[int, Query(description="Maximum number of products to return")] = 1000,
-    sortby: Annotated[str, Query(description="Sort by +/-fieldName (ascending/descending)")] = "+doNotSort",
+    sortby: Annotated[str, Query(description="Sort by +/-fieldName (ascending/descending)")] = "-datetime",
 ) -> list[dict] | dict:  # pylint: disable=too-many-locals
     """Endpoint to retrieve a list of products from the CADU system for a specified station.
 

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -106,7 +106,7 @@ def test_valid_endpoint_request_list(
         assert any("some_id_2" in product["properties"].values() for product in data["features"])
         assert any("some_id_3" in product["properties"].values() for product in data["features"])
         assert db_handler.get(db, name="S2L1C.raw").status == EDownloadStatus.NOT_STARTED
-        assert data["features"][0] == expected_feature
+        assert expected_feature in data["features"]
 
         # For each field on which to sort
         for field_to_sort in fields_to_sort:

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -123,7 +123,7 @@ def test_valid_endpoint_request_list(
                 # Assert that the features are sorted
                 sorted_features = sorted(
                     features,
-                    key=lambda feature: feature["properties"][field_to_sort],
+                    key=lambda feature, field=field_to_sort: feature["properties"][field],
                     reverse=reverse,
                 )
                 assert features == sorted_features

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -99,14 +99,18 @@ def test_valid_endpoint_request_list(
             # Check that product is not in database, this should raise HTTPException
             db_handler.get(db, name="S2L1C.raw")
             assert False
-        data = client.get(endpoint).json()
+        features = client.get(endpoint).json()["features"]
         # check that request returned more than 1 element
-        assert len(data["features"]) == len(expected_products)
+        assert len(features) == len(expected_products)
         # Check if ids and names are matching with given parameters
-        assert any("some_id_2" in product["properties"].values() for product in data["features"])
-        assert any("some_id_3" in product["properties"].values() for product in data["features"])
+        assert any("some_id_2" in product["properties"].values() for product in features)
+        assert any("some_id_3" in product["properties"].values() for product in features)
         assert db_handler.get(db, name="S2L1C.raw").status == EDownloadStatus.NOT_STARTED
-        assert expected_feature in data["features"]
+        assert expected_feature in features
+
+        # Assert that the features are sorted by descending datetime by default
+        sorted_features = sorted(features, key=lambda feature: feature["properties"]["datetime"], reverse=True)
+        assert features == sorted_features
 
         # For each field on which to sort
         for field_to_sort in fields_to_sort:
@@ -114,13 +118,15 @@ def test_valid_endpoint_request_list(
             for reverse in [False, True]:
                 # Call the endpoint again, but this time by sorting results
                 sign = "-" if reverse else "+"
-                data = client.get(endpoint, params={"sortby": f"{sign}{field_to_sort}"}).json()
+                features = client.get(endpoint, params={"sortby": f"{sign}{field_to_sort}"}).json()["features"]
 
-                # Get only the requested fields from the result
-                fields = [feature["properties"][field_to_sort] for feature in data["features"]]
-
-                # Check that the list is equal to the sorted list
-                assert fields == sorted(fields, reverse=reverse)
+                # Assert that the features are sorted
+                sorted_features = sorted(
+                    features,
+                    key=lambda feature: feature["properties"][field_to_sort],
+                    reverse=reverse,
+                )
+                assert features == sorted_features
 
 
 @pytest.mark.unit

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -123,7 +123,7 @@ def test_valid_endpoint_request_list(
                 # Assert that the features are sorted
                 sorted_features = sorted(
                     features,
-                    key=lambda feature, field=field_to_sort: feature["properties"][field],
+                    key=lambda feature, field=field_to_sort: feature["properties"][field],  # type: ignore
                     reverse=reverse,
                 )
                 assert features == sorted_features


### PR DESCRIPTION
As per ESA/ADS default sorting order of search endpoints should be descending datetime.