### PR TITLE
Feat rspy139 - Catalog download asset

### DIFF
--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -239,7 +239,9 @@ class UserCatalogMiddleware(BaseHTTPMiddleware):
             except Exception as e:  # pylint: disable=broad-except
                 # If something fails while publishing data into catalog, revert files moved into catalog bucket
                 clear_catalog_bucket(s3_handler, content)
-                return JSONResponse(f"Bad request, {e}", status_code=400)
+                body = [chunk async for chunk in response.body_iterator]
+                response_content = json.loads(b"".join(body).decode())
+                return JSONResponse(f"Bad request, {response_content}, {e}", status_code=400)
             # If catalog publication is successful, remove files from temp bucket
             clear_temp_bucket(s3_handler, content)
             return JSONResponse(content, status_code=response.status_code)

--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -214,7 +214,7 @@ class UserCatalogMiddleware(BaseHTTPMiddleware):
             return "Could not generate presigned url", 400
         return response, 302
 
-    async def dispatch(self, request, call_next):  # pylint: disable=too-many-return-statements
+    async def dispatch(self, request, call_next):  # pylint: disable=too-many-return-statements,too-many-branches
         """Redirect the user catalog specific endpoint and adapt the response content."""
         s3_handler = None
         ids = get_ids(request.scope["path"])

--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -18,6 +18,7 @@ import pathlib
 from typing import Any
 from urllib.parse import urlparse
 
+import botocore.exceptions
 from rs_server_catalog.user_handler import (
     add_user_prefix,
     filter_collections,
@@ -33,6 +34,7 @@ from rs_server_common.s3_storage_handler.s3_storage_handler import (
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
+PRESIGNED_URL_EXPIRATION_TIME = 1800  # 30 minutes
 bucket_info_path = pathlib.Path(__file__).parent / "config" / "buckets.json"
 
 with open(bucket_info_path, encoding="utf-8") as bucket_info_file:
@@ -157,12 +159,31 @@ class UserCatalogMiddleware(BaseHTTPMiddleware):
         return content
 
     def generate_presigned_url(self, content, path):
+        """This function is used to generate a time-limited download url"""
         # Assume that pgstac already selected the correct asset id
         # just check type, generate and return url
-        # s3_path = content['asset']
-        import pdb
-        pdb.set_trace()
-        return "URL", 302
+        asset_id = path.split("/")[-1]
+        s3_path = content["assets"][asset_id]["alternate"]["s3"]["href"].replace(
+            bucket_info["catalog-bucket"]["S3_ENDPOINT"],
+            "",
+        )
+        try:
+            handler = S3StorageHandler(
+                os.environ["S3_ACCESSKEY"],
+                os.environ["S3_SECRETKEY"],
+                os.environ["S3_ENDPOINT"],
+                os.environ["S3_REGION"],
+            )
+            response = handler.s3_client.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": bucket_info["catalog-bucket"]["name"], "Key": s3_path},
+                ExpiresIn=PRESIGNED_URL_EXPIRATION_TIME,
+            )
+        except KeyError:
+            return "Could not find s3 credentials"
+        except botocore.exceptions.ClientError:
+            return "Could not generate presigned url"
+        return response, 302
 
     async def dispatch(self, request, call_next):
         """Redirect the user catalog specific endpoint and adapt the response content."""
@@ -201,12 +222,12 @@ class UserCatalogMiddleware(BaseHTTPMiddleware):
                 content = self.remove_user_from_objects(content, user, "collections")
                 content = self.adapt_links(content, ids["owner_id"], ids["collection_id"], "collections")
             elif (
-                    "/collection" in request.scope["path"] and "items" not in request.scope["path"]
+                "/collection" in request.scope["path"] and "items" not in request.scope["path"]
             ):  # /catalog/owner_id/collections/collection_id
                 content = remove_user_from_collection(content, user)
                 content = self.adapt_object_links(content, user)
             elif (
-                    "items" in request.scope["path"] and not ids["item_id"]
+                "items" in request.scope["path"] and not ids["item_id"]
             ):  # /catalog/owner_id/collections/collection_id/items
                 content = self.remove_user_from_objects(content, user, "features")
                 content = self.adapt_links(content, ids["owner_id"], ids["collection_id"], "features")

--- a/services/catalog/tests/test_endpoints.py
+++ b/services/catalog/tests/test_endpoints.py
@@ -594,3 +594,8 @@ def test_incorrect_feature_publish(client, a_incorrect_feature, owner, collectio
 def test_status_code_200_search_if_good_endpoint(client):  # pylint: disable=missing-function-docstring
     response = client.get("/catalog/search")
     assert response.status_code == 200
+
+
+def test_generate_download_presigned_url(client):
+    response = client.get("/catalog/toto/collections/S1_L1/items/fe916452-ba6f-4631-9154-c249924a122d/download/COG")
+    assert response.status_code == 302

--- a/services/catalog/tests/test_endpoints.py
+++ b/services/catalog/tests/test_endpoints.py
@@ -597,5 +597,37 @@ def test_status_code_200_search_if_good_endpoint(client):  # pylint: disable=mis
 
 
 def test_generate_download_presigned_url(client):
+    """Test used to verify the generation of a presigned url for a download."""
+    # Start moto server
+    moto_endpoint = "http://localhost:8077"
+    export_aws_credentials()
+    secrets = {"s3endpoint": moto_endpoint, "accesskey": None, "secretkey": None, "region": ""}
+    s3_handler = S3StorageHandler(
+        secrets["accesskey"],
+        secrets["secretkey"],
+        secrets["s3endpoint"],
+        secrets["region"],
+    )
+    server = ThreadedMotoServer(port=8077)
+    server.start()
+
+    # Upload a file to catalog-bucket
+    catalog_bucket = "catalog-bucket"
+    s3_handler.s3_client.create_bucket(Bucket=catalog_bucket)
+    object_cotent = "testing\n"
+    s3_handler.s3_client.put_object(
+        Bucket=catalog_bucket,
+        Key="S1_L1/images/may24C355000e4102500n.tif",
+        Body=object_cotent,
+    )
+
     response = client.get("/catalog/toto/collections/S1_L1/items/fe916452-ba6f-4631-9154-c249924a122d/download/COG")
     assert response.status_code == 302
+    # Check that response is a url not file content!
+    assert response.content != object_cotent
+    # TBD Check file with byte-stream
+    server.stop()
+    clear_aws_credentials()
+
+
+# TBA: Tests fail cases


### PR DESCRIPTION
This PR generates a url that can download files from s3 using information stored in catalog.


Sending a GET request to "/catalog/toto/collections/S1_L1/items/fe916452-ba6f-4631-9154-c249924a122d/download/COG" will return a 30 minute link (http://localhost:8077/catalog-bucket/S1_L1/images/may24C355000e4102500n.tif?AWSAccessKeyId=testing&Signature=Rtx4Y1j16lgGWMB%2BWSjMo6LI1LA%3D&Expires=1709214912) that can directly download file stored in catalog (asset alternate href).