### PR TITLE
RSPY299: Disable external eodag sources

### DIFF
--- a/services/common/rs_server_common/data_retrieval/eodag_provider.py
+++ b/services/common/rs_server_common/data_retrieval/eodag_provider.py
@@ -71,6 +71,8 @@ class EodagProvider(Provider):
             # Use thread-lock
             with EodagProvider.lock:
                 os.environ["EODAG_CFG_DIR"] = self.eodag_cfg_dir.name
+                # disable product types discovery
+                os.environ["EODAG_EXT_PRODUCT_TYPES_CFG_FILE"] = ""
                 return EODataAccessGateway(config_file.as_posix())
         except Exception as e:
             raise CreateProviderFailed(f"Can't initialize {self.provider} provider") from e


### PR DESCRIPTION
Disabled eodag search to external services as per:

https://eodag.readthedocs.io/en/latest/notebooks/api_user_guide/2_providers_products_available.html#Product-types-discovery