### PR TITLE
Feat rspy282/document stac catalog metadata

### DIFF
--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -568,19 +568,18 @@ collection owned by the '{user}' user. Additionally, modifying the 'owner' field
         return collections
 
     def update_stac_catalog_metadata(self, metadata: dict):
-        """Update the metadata fields from a catalog, following the US RSPY-282
+        """Update the metadata fields from a catalog
 
         Args:
-            metadata (dict): The metdata that has to be updated. The fields id, title,
+            metadata (dict): The metadata that has to be updated. The fields id, title,
                             description and stac_version are to be updated, by using the env vars which have
                             to be set before starting the app/pod. The existing values are used if
                             the env vars are not found
         """
-        if metadata.get("type") != "Catalog":
-            return
-        for key in ["id", "title", "description", "stac_version"]:
-            if key in metadata:
-                metadata[key] = os.environ.get(f"CATALOG_METADATA_{key.upper()}", metadata[key])
+        if metadata.get("type") == "Catalog":
+            for key in ["id", "title", "description", "stac_version"]:
+                if key in metadata:
+                    metadata[key] = os.environ.get(f"CATALOG_METADATA_{key.upper()}", metadata[key])
 
     async def manage_get_response(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         self,

--- a/services/catalog/tests/test_endpoints.py
+++ b/services/catalog/tests/test_endpoints.py
@@ -79,6 +79,40 @@ def test_status_code_200_docs_if_good_endpoints(client):  # pylint: disable=miss
     assert response.status_code == fastapi.status.HTTP_200_OK
 
 
+def test_update_stac_catalog_metadata(client):
+    """
+    Test the update od the stac catalog metdata when the /catalog/ endpoint is called
+    """
+    default_txt = "stac-fastapi"
+    id_txt = "rs-python"
+    title_txt = "RS-PYTHON STAC Catalog"
+    description_txt = "STAC catalog of Copernicus Reference System Python"
+
+    response = client.get("/catalog/")
+    assert response.status_code == fastapi.status.HTTP_200_OK
+    resp_dict = json.loads(response.content)
+    assert resp_dict["id"] == default_txt
+    assert resp_dict["title"] == default_txt
+    assert resp_dict["description"] == default_txt
+
+    os.environ["CATALOG_METADATA_ID"] = id_txt
+    response = client.get("/catalog/")
+    assert response.status_code == fastapi.status.HTTP_200_OK
+    resp_dict = json.loads(response.content)
+    assert resp_dict["id"] == id_txt
+    assert resp_dict["title"] == default_txt
+    assert resp_dict["description"] == default_txt
+
+    os.environ["CATALOG_METADATA_TITLE"] = title_txt
+    os.environ["CATALOG_METADATA_DESCRIPTION"] = description_txt
+    response = client.get("/catalog/")
+    assert response.status_code == fastapi.status.HTTP_200_OK
+    resp_dict = json.loads(response.content)
+    assert resp_dict["id"] == id_txt
+    assert resp_dict["title"] == title_txt
+    assert resp_dict["description"] == description_txt
+
+
 class TestCatalogSearchEndpoint:
     """This class contains integration tests for the endpoint '/catalog/search'."""
 

--- a/services/catalog/tests/test_endpoints.py
+++ b/services/catalog/tests/test_endpoints.py
@@ -81,7 +81,7 @@ def test_status_code_200_docs_if_good_endpoints(client):  # pylint: disable=miss
 
 def test_update_stac_catalog_metadata(client):
     """
-    Test the update od the stac catalog metdata when the /catalog/ endpoint is called
+    Test the update of the stac catalog metadata when the `/catalog/ endpoint is called
     """
     default_txt = "stac-fastapi"
     id_txt = "rs-python"


### PR DESCRIPTION
Update the stac catalog metadata by using environment variables. In cluster running case, the values for these env vars should be set in the values.yaml file