### PR TITLE
Fix the status for GET /jobs endpoint

### DIFF
--- a/services/staging/rs_server_staging/main.py
+++ b/services/staging/rs_server_staging/main.py
@@ -40,7 +40,11 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
-from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND
+from starlette.status import (
+    HTTP_200_OK,
+    HTTP_404_NOT_FOUND,
+    HTTP_503_SERVICE_UNAVAILABLE,
+)
 
 from .rspy_models import ProcessMetadataModel
 
@@ -283,19 +287,17 @@ async def get_job_status_endpoint(job_id: str = Path(..., title="The ID of the j
     job = app.extra["process_manager"].get_job(job_id)
     if job:
         return job
-    raise HTTPException(status_code=404, detail="Job not found")
+    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"Job with ID {job_id} not found")
 
 
 @router.get("/jobs")
 async def get_jobs_endpoint():
     """Returns the status of all jobs."""
-    jobs = app.extra["process_manager"].get_jobs()
-
-    if jobs:
-        return JSONResponse(status_code=HTTP_200_OK, content=jobs)
-
-    # If no jobs are found, return 404 with appropriate message
-    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="No job found")
+    try:
+        return app.extra["process_manager"].get_jobs()
+    except Exception as e:
+        # Handle exceptions and return an appropriate error message
+        raise HTTPException(status_code=HTTP_503_SERVICE_UNAVAILABLE, detail=str(e)) from e
 
 
 @router.delete("/jobs/{job_id}")
@@ -304,7 +306,7 @@ async def delete_job_endpoint(job_id: str = Path(..., title="The ID of the job t
     success = app.extra["process_manager"].delete_job(job_id)
     if success:
         return {"message": f"Job {job_id} deleted successfully"}
-    raise HTTPException(status_code=404, detail=f"Job with ID {job_id} not found")
+    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"Job with ID {job_id} not found")
 
 
 @router.get("/jobs/{job_id}/results")
@@ -315,7 +317,7 @@ async def get_specific_job_result_endpoint(job_id: str = Path(..., title="The ID
     if job:
         return JSONResponse(status_code=HTTP_200_OK, content=job["status"])
 
-    raise HTTPException(status_code=404, detail=f"Job with ID {job_id} not found")
+    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"Job with ID {job_id} not found")
 
 
 # Configure OpenTelemetry

--- a/services/staging/tests/test_staging.py
+++ b/services/staging/tests/test_staging.py
@@ -25,7 +25,11 @@ from rs_server_staging.main import (
     init_pygeoapi,
 )
 from sqlalchemy.exc import SQLAlchemyError
-from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND
+from starlette.status import (
+    HTTP_200_OK,
+    HTTP_404_NOT_FOUND,
+    HTTP_503_SERVICE_UNAVAILABLE,
+)
 
 expected_jobs_test = [
     {
@@ -186,7 +190,8 @@ async def test_get_jobs_endpoint(mocker, set_db_env_var, staging_client):  # pyl
 
     # Mock app.extra to ensure 'db_table' exists
     mock_db_table = mocker.MagicMock()
-    mock_db_table.get_jobs.return_value = mock_jobs  # Simulate postgres returning jobs
+    # Simulate postgres returning jobs
+    mock_db_table.get_jobs.return_value = {"jobs": list(mock_jobs), "numberMatched": 2}
 
     # Patch app.extra with the mock db_table
     mocker.patch.object(staging_client.app, "extra", {"process_manager": mock_db_table})
@@ -195,14 +200,29 @@ async def test_get_jobs_endpoint(mocker, set_db_env_var, staging_client):  # pyl
     response = staging_client.get("/jobs")
     # Assert the correct response is returned
     assert response.status_code == HTTP_200_OK
-    assert response.json() == mock_jobs  # Check if the returned data matches the mocked jobs
+    # Check if the returned data matches the mocked jobs
+    assert response.json() == {"jobs": list(mock_jobs), "numberMatched": 2}
 
     # Mock with an empty db, should return 404 since there are no jobs.
-    mock_db_table.get_jobs.return_value = []
+    mock_db_table.get_jobs.return_value = {"jobs": [], "numberMatched": 0}
+
+    # Patch app.extra with the mock db_table
+    mocker.patch.object(staging_client.app, "extra", {"process_manager": mock_db_table})
 
     response = staging_client.get("/jobs")
 
-    assert response.status_code == HTTP_404_NOT_FOUND
+    assert response.status_code == HTTP_200_OK
+    # Check if the returned data matches 0 jobs
+    assert response.json() == {"jobs": [], "numberMatched": 0}
+
+    # Simulate an exception
+    mock_db_table.get_jobs.side_effect = Exception("get_jobs failed")
+    # Patch app.extra with the mock db_table
+    mocker.patch.object(staging_client.app, "extra", {"process_manager": mock_db_table})
+    # Call the API
+    response = staging_client.get("/jobs")
+    assert response.status_code == HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json() == {"message": "get_jobs failed"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Directly return the response from the PostgreSQLManager get_jobs function when invoking the /jobs endpoint