### PR TITLE
RSPY-567 - set end_datetime only if start_datetime is also set

### DIFF
--- a/services/cadip/rs_server_cadip/cadip_utils.py
+++ b/services/cadip/rs_server_cadip/cadip_utils.py
@@ -28,11 +28,11 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 import eodag
-import stac_pydantic
 import yaml
 from fastapi import HTTPException, status
 from rs_server_common.stac_api_common import map_stac_platform
 from rs_server_common.utils.logging import Logging
+from stac_pydantic import ItemCollection, ItemProperties
 from stac_pydantic.shared import Asset
 
 DEFAULT_GEOM = {"geometry": "POLYGON((180 -90, 180 90, -180 90, -180 -90, 180 -90))"}
@@ -106,10 +106,10 @@ def from_session_expand_to_dag_serializer(input_sessions: List[eodag.EOProduct])
 
 
 def from_session_expand_to_assets_serializer(
-    feature_collection: stac_pydantic.ItemCollection,
+    feature_collection: ItemCollection,
     input_session: eodag.EOProduct,
     mapper: dict,
-) -> stac_pydantic.ItemCollection:
+) -> ItemCollection:
     """
     Associate all expanded files with session from feature_collection and create a stac_pydantic.Asset for each file.
     """
@@ -199,18 +199,31 @@ def link_assets_to_session(session_data, assets_dict, mapper):
             asset: Asset = Asset(title=asset_dict.pop("id"), roles=["cadu"], **asset_dict)
             feature.assets.update({asset.title: asset})
         try:
+            properties: ItemProperties = feature.properties
+            start_date = properties.start_datetime
             end_date = max(
-                (datetime.fromisoformat(item["PublicationDate"].replace("Z", "")) for item in matching_assets),
+                (
+                    datetime.fromisoformat(item["PublicationDate"].replace("Z", "")).replace(tzinfo=timezone.utc)
+                    for item in matching_assets
+                ),
                 default=None,
             )
-            feature.properties.end_datetime = datetime.fromisoformat(str(end_date)).replace(tzinfo=timezone.utc)
-        except ValueError:
-            logger.warning(f"Cannot update end datetime for {feature.id}")
+            # https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#date-and-time-range
+            # Using one of the fields REQUIRES inclusion of the other field as well to enable a user to search STAC
+            # records by the provided times. So if you use start_datetime you need to add end_datetime and vice-versa.
+            if start_date and end_date:
+                properties.end_datetime = end_date
+            elif start_date or end_date:
+                logger.warning(f"{feature.id} has only one time range property: {start_date}/{end_date}")
+                properties.start_datetime = None
+                properties.end_datetime = None
+        except ValueError as e:
+            logger.warning(f"Cannot update start/end datetime for {feature.id}: {e}")
             continue
     return session_data
 
 
-def prepare_collection(collection: stac_pydantic.ItemCollection) -> stac_pydantic.ItemCollection:
+def prepare_collection(collection: ItemCollection) -> ItemCollection:
     """Used to create a more complex mapping on platform/constallation from odata to stac."""
     for feature in collection.features:
         feature.properties.platform, feature.properties.constellation = cadip_reverse_map_mission(

--- a/services/cadip/rs_server_cadip/cadip_utils.py
+++ b/services/cadip/rs_server_cadip/cadip_utils.py
@@ -197,7 +197,10 @@ def link_assets_to_session(session_data, assets_dict, mapper):
                 map_key: asset_item[map_value] for map_key, map_value in mapper.items() if map_value in asset_item
             }
             asset: Asset = Asset(title=asset_dict.pop("id"), roles=["cadu"], **asset_dict)
-            feature.assets.update({asset.title: asset})
+            if asset.title:
+                feature.assets.update({asset.title: asset})
+            else:
+                logger.error(f"Ignored CADU asset without title: {asset}")
         try:
             properties: ItemProperties = feature.properties
             start_date = properties.start_datetime

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -776,5 +776,5 @@ def create_stac_collection(
             items.append(item)
         except ValidationError as e:
             logger.error(f"STAC validation error for {feature_tmp} (STAC conversion of {product_data}): {e}")
-            raise
+            continue
     return stac_pydantic.ItemCollection(features=items, type="FeatureCollection")

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -775,6 +775,6 @@ def create_stac_collection(
             item.stac_extensions = [str(se) for se in item.stac_extensions]  # type: ignore
             items.append(item)
         except ValidationError as e:
-            logger.error(f"STAC validation error for {feature_tmp} (STAC conversion of {product_data})", e)
+            logger.error(f"STAC validation error for {feature_tmp} (STAC conversion of {product_data}): {e}")
             raise
     return stac_pydantic.ItemCollection(features=items, type="FeatureCollection")

--- a/services/common/rs_server_common/utils/utils.py
+++ b/services/common/rs_server_common/utils/utils.py
@@ -440,7 +440,25 @@ def odata_to_stac(feature_template: dict, odata_dict: dict, odata_stac_mapper: d
                 feature_template["id"] = odata_dict[eodag_key]
             elif stac_key in feature_template["assets"]["file"]:
                 feature_template["assets"]["file"][stac_key] = odata_dict[eodag_key]
+    # to pass pydantic validation, make sure we don't have a single timerange value
+    check_and_fix_timerange(feature_template)
     return feature_template
+
+
+def check_and_fix_timerange(item: dict):
+    """This function ensures the item does not have a single timerange value"""
+    properties = item.get("properties", {})
+
+    start_dt = properties.get("start_datetime")
+    end_dt = properties.get("end_datetime")
+    dt = properties.get("datetime")
+
+    if start_dt and not end_dt:
+        properties["end_datetime"] = max(start_dt, dt) if dt else start_dt
+        logger.warning(f"Forced end_datetime property in {item}")
+    elif end_dt and not start_dt:
+        properties.pop("end_datetime", None)
+        logger.warning(f"Removed end_datetime property from {item}")
 
 
 def extract_eo_product(eo_product: EOProduct, mapper: dict) -> dict:

--- a/services/common/tests/utils/test_utils.py
+++ b/services/common/tests/utils/test_utils.py
@@ -1,0 +1,72 @@
+# Copyright 2024 CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for utility funtions defined in utils.py."""
+
+
+from rs_server_common.utils.utils import check_and_fix_timerange
+
+
+def test_add_end_datetime():
+    """Test when start_datetime exists but end_datetime is missing"""
+    item = {
+        "properties": {
+            "start_datetime": "2024-01-01T00:00:00Z",
+            "end_datetime": None,
+            "datetime": "2024-01-02T00:00:00Z",
+        },
+    }
+    check_and_fix_timerange(item)
+    assert item["properties"]["end_datetime"] == "2024-01-02T00:00:00Z"
+
+
+def test_remove_end_datetime():
+    """Test when end_datetime exists but start_datetime is missing"""
+    item = {
+        "properties": {
+            "start_datetime": None,
+            "end_datetime": "2024-01-02T00:00:00Z",
+            "datetime": "2024-01-01T00:00:00Z",
+        },
+    }
+    check_and_fix_timerange(item)
+    assert item["properties"].get("end_datetime", None) is None
+
+
+def test_no_change():
+    """Test when both start_datetime and end_datetime are properly defined"""
+    item = {
+        "properties": {
+            "start_datetime": "2024-01-01T00:00:00Z",
+            "end_datetime": "2024-01-02T00:00:00Z",
+            "datetime": None,
+        },
+    }
+    check_and_fix_timerange(item)
+    assert item["properties"]["start_datetime"] == "2024-01-01T00:00:00Z"
+    assert item["properties"]["end_datetime"] == "2024-01-02T00:00:00Z"
+
+
+def test_missing_datetimes():
+    """Test when both start_datetime and end_datetime are missing"""
+    item = {
+        "properties": {
+            "start_datetime": None,
+            "end_datetime": None,
+            "datetime": None,
+        },
+    }
+    check_and_fix_timerange(item)
+    assert item["properties"].get("end_datetime", None) is None
+    assert item["properties"].get("start_datetime", None) is None

--- a/services/common/tests/utils/test_utils2.py
+++ b/services/common/tests/utils/test_utils2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for utility funtions."""
+"""Unit tests for utility funtions defined in utils2.py."""
 
 import requests
 import responses
@@ -23,7 +23,7 @@ from rs_server_common.utils.utils2 import read_response_error
 def test_response_error():
     """Test reading responses errors."""
 
-    dummy_href = "http://DUMMY_HREF"
+    dummy_href = "https://DUMMY_HREF"
     detail = "detail message"
     error = "error message"
     content = "response content"

--- a/tests/test_cadip_utils.py
+++ b/tests/test_cadip_utils.py
@@ -1,0 +1,116 @@
+# Copyright 2024 CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the CADIP utilities."""
+
+import json
+import os.path as osp
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rs_server_cadip.cadip_utils import link_assets_to_session
+from stac_pydantic import Item, ItemCollection, ItemProperties
+from stac_pydantic.links import Links
+
+CADIP_CONFIG = Path(osp.realpath(osp.dirname(__file__))).parent / "services/cadip/config"
+
+
+def test_link_assets_to_session_no_start_no_end():
+    """start_datetime not set, end_datetime not set"""
+    do_test_link_assets_to_session(False, False)
+
+
+def test_link_assets_to_session_no_start_but_end():
+    """start_datetime not set, end_datetime set"""
+    do_test_link_assets_to_session(False, True)
+
+
+def test_link_assets_to_session_start_no_end():
+    """start_datetime set, end_datetime not set"""
+    do_test_link_assets_to_session(True, False)
+
+
+def test_link_assets_to_session_start_and_end():
+    """start_datetime set, end_datetime set"""
+    do_test_link_assets_to_session(True, True)
+
+
+def do_test_link_assets_to_session(start: bool, end: bool):
+    """checks correct behaviour of link_assets_to_session for timerange properties"""
+    with open(CADIP_CONFIG / "cadip_stac_mapper.json", encoding="utf-8") as mapper:
+        item: Item = Item(
+            type="Feature",
+            stac_version="1.0.0",
+            id="S1A_20241202183845056817",
+            properties=ItemProperties(
+                datetime=datetime.fromisoformat("2024-12-02T18:38:45").replace(tzinfo=timezone.utc),
+                start_datetime=(
+                    datetime.fromisoformat("2024-12-02T18:00:00").replace(tzinfo=timezone.utc) if start else None
+                ),
+                end_datetime=(
+                    datetime.fromisoformat("2024-12-02T18:00:00").replace(tzinfo=timezone.utc) if start else None
+                ),
+                gsd=None,
+            ),
+            geometry=None,
+            assets={},
+            links=Links([]),
+        )
+        session_data = ItemCollection(features=[item], type="FeatureCollection")
+        assets: list[dict] = (
+            [
+                {
+                    "Name": "chunk_1.tgz",
+                    "SessionId": "S1A_20241202183845056817",
+                    "PublicationDate": "2024-12-02T18:49:55Z",
+                    "href": "https://localhost/chunk_1.tgz",
+                },
+            ]
+            if end
+            else []
+        )
+
+        link_assets_to_session(session_data, assets, json.loads(mapper.read()))
+
+        assert item.properties.datetime == datetime(  # pylint: disable=no-member
+            2024,
+            12,
+            2,
+            18,
+            38,
+            45,
+            tzinfo=timezone.utc,
+        )  # pylint: disable=no-member
+        if start and end:
+            assert item.properties.start_datetime == datetime(  # pylint: disable=no-member
+                2024,
+                12,
+                2,
+                18,
+                0,
+                0,
+                tzinfo=timezone.utc,
+            )
+            assert item.properties.end_datetime == datetime(  # pylint: disable=no-member
+                2024,
+                12,
+                2,
+                18,
+                49,
+                55,
+                tzinfo=timezone.utc,
+            )
+        else:
+            assert item.properties.start_datetime is None  # pylint: disable=no-member
+            assert item.properties.end_datetime is None  # pylint: disable=no-member


### PR DESCRIPTION
https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#date-and-time-range

> Using one of the fields REQUIRES inclusion of the other field as well to enable a user to search STAC records by the provided times. So if you use start_datetime you need to add end_datetime and vice-versa.

Real CADIP stations often return incomplete data, we must support all cases.