### PR TITLE
Replace emacs by emacs-nox to exclude GTK from the security analyses

### DIFF
--- a/.github/scripts/git_debug_image.sh
+++ b/.github/scripts/git_debug_image.sh
@@ -25,9 +25,9 @@ ROOT_DIR="$(realpath $SCRIPT_DIR/..)"
 # Read input arguments
 BRANCH_NAME="$1" # git branch name
 
-# Install components in the docker iamges
+# Install components in the docker images
 apt update
-apt install -y git vim emacs
+apt install -y git vim emacs-nox
 
 # Add aliases to bash
 cat << EOF >> /home/user/.bashrc


### PR DESCRIPTION
"emacs" includes emacs-gtk, which includes a lot of graphical components with their CVEs.

emacs-nox contains only the terminal editor.