### PR TITLE
Docker: Perform apt upgrade to get security fixes

### DIFF
--- a/services/adgs/.github/Dockerfile
+++ b/services/adgs/.github/Dockerfile
@@ -17,7 +17,7 @@
 FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm AS builder
 
 # Install dependencies
-RUN apt update && apt install -y libpq-dev gcc
+RUN apt update && apt upgrade -y && apt install -y libpq-dev gcc
 
 # TODO: remove this after we use an official git version tag for eodag
 RUN apt install -y git
@@ -40,7 +40,7 @@ FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm
 
 # Install dependencies necessary for execution (e.g. libpq) not compilation (gcc)
 RUN \
-    apt update && \
+    apt update && apt upgrade -y && \
     apt install -y libpq-dev libexpat1 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 

--- a/services/cadip/.github/Dockerfile
+++ b/services/cadip/.github/Dockerfile
@@ -17,7 +17,7 @@
 FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm AS builder
 
 # Install dependencies
-RUN apt update && apt install -y libpq-dev gcc
+RUN apt update && apt upgrade -y && apt install -y libpq-dev gcc
 
 # TODO: remove this after we use an official git version tag for eodag
 RUN apt install -y git
@@ -40,7 +40,7 @@ FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm
 
 # Install dependencies necessary for execution (e.g. libpq) not compilation (gcc)
 RUN \
-    apt update && \
+    apt update && apt upgrade -y && \
     apt install -y libpq-dev libexpat1 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 

--- a/services/catalog/.github/Dockerfile
+++ b/services/catalog/.github/Dockerfile
@@ -17,7 +17,7 @@
 FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm AS builder
 
 # Install dependencies
-RUN apt update && apt install -y libpq-dev gcc
+RUN apt update && apt upgrade -y && apt install -y libpq-dev gcc
 
 # TODO: remove this after we use an official git version tag for eodag
 RUN apt install -y git
@@ -40,7 +40,7 @@ FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm
 
 # Install dependencies necessary for execution (e.g. libpq) not compilation (gcc)
 RUN \
-    apt update && \
+    apt update && apt upgrade -y && \
     apt install -y libpq-dev libexpat1 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 

--- a/services/frontend/.github/Dockerfile
+++ b/services/frontend/.github/Dockerfile
@@ -17,7 +17,7 @@
 FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm AS builder
 
 # Install dependencies
-RUN apt update && apt install -y libpq-dev gcc
+RUN apt update && apt upgrade -y && apt install -y libpq-dev gcc
 
 # Update pip version
 RUN pip install --no-cache-dir --upgrade pip
@@ -34,6 +34,9 @@ RUN cd /tmp/whl && pip install --no-cache-dir rs_server_frontend-*.whl
 
 # Final stage. Don't use alpine, it's too different from the build stage.
 FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm
+
+# Update dependencies
+RUN apt update && apt upgrade -y
 
 # Copy the python installation from the build stage
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages

--- a/services/staging/.github/Dockerfile
+++ b/services/staging/.github/Dockerfile
@@ -17,7 +17,7 @@
 FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm AS builder
 
 # Install dependencies
-RUN apt update && apt install -y libpq-dev gcc
+RUN apt update && apt upgrade -y && apt install -y libpq-dev gcc
 
 # Update pip version
 RUN pip install --no-cache-dir --upgrade pip
@@ -40,7 +40,7 @@ FROM ghcr.io/rs-python/python:3.11.7-slim-bookworm
 
 # Install dependencies necessary for execution (e.g. libpq) not compilation (gcc)
 RUN \
-    apt update && \
+    apt update && apt upgrade -y && \
     apt install -y libpq-dev libexpat1 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 


### PR DESCRIPTION
The apt install already upgrades a few dependencies.

Explicitly upgrade all packages to get as many security fixes as possible.

This is the current outcome for the builder:

```
#8 2.567 Calculating upgrade...
#8 2.942 The following packages will be upgraded:
#8 2.942   base-files bash bsdutils libblkid1 libc-bin libc6 libexpat1 libgnutls30
#8 2.943   libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 libmount1
#8 2.943   libseccomp2 libsmartcols1 libsqlite3-0 libssl3 libsystemd0 libudev1 libuuid1
#8 2.943   mount openssl tar tzdata usr-is-merged util-linux util-linux-extra
#8 2.976 27 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
#8 2.976 Need to get 14.9 MB of archives.
#8 2.976 After this operation, 28.7 kB of additional disk space will be used.
```

And for the image:
```
```