### PR TITLE
Restrict Trivy scan to CRITICAL and HIGH vulnerabilities to get below the 5000 Github Code Scanning Alerts cap

### DIFF
--- a/.github/actions/publish-docker/action.yml
+++ b/.github/actions/publish-docker/action.yml
@@ -140,7 +140,8 @@ runs:
         format: sarif
         output: trivy-results-docker.sarif
         exit-code: 0
-        #severity: HIGH,CRITICAL
+        limit-severities-for-sarif: true
+        severity: HIGH,CRITICAL
         #timeout: '30m'
 
     - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Currently we can't see the list of code scanning alerts since their number exceeded 5000.

After creating a [ticket to Github Support](https://support.github.com/ticket/personal/0/3166055), I got the following response:

> I'm sorry, but there is not an option to combine alerts at this time and our engineers have indicated that 5000 is the limit for alerts to display in the UI at this time. If you would like to see changes around this, we invite you to share your feedback in our [official GitHub community discussions repository](https://github.com/community/community/discussions).
>  
> Please note that while the Product team reads and evaluates all feedback, we cannot guarantee a response to every submission.