### PR TITLE
Remove unwanted 'provider' field from Staging request body

### DIFF
--- a/resources/sync_config_files.py
+++ b/resources/sync_config_files.py
@@ -129,6 +129,7 @@ yaml.add_representer(LiteralStr, represent_literal_str)
 
 # Replace local urls like http(s)://(127.0.0.1|localhost):5xxx
 REGEX_URL = re.compile(r"(https?://)(127.0.0.1|localhost):5\d+")
+REGEX_DOMAIN = re.compile(r"mockup-.+-svc.processing.svc.cluster.local")
 
 # Replace k8s values
 REGEX_RANGE_START = r"({{-?\s*range\s.*-?}})"
@@ -324,13 +325,13 @@ def copy_to_demo(input_path_relative: str):
             if not isinstance(value, str):
                 raise RuntimeError(f"Invalid argument: {value}")
             if station.adgs:
-                return re.sub(REGEX_URL, r"\g<1>adgs-station:5000", value)
+                return re.sub(REGEX_DOMAIN, "adgs-station", re.sub(REGEX_URL, r"\g<1>adgs-station:5000", value))
             if station.cadip:
-                return re.sub(REGEX_URL, r"\g<1>cadip-station:5000", value)
+                return re.sub(REGEX_DOMAIN, "cadip-station", re.sub(REGEX_URL, r"\g<1>cadip-station:5000", value))
             if station.lta:
-                return re.sub(REGEX_URL, r"\g<1>lta-station:5000", value)
+                return re.sub(REGEX_DOMAIN, "lta-station", re.sub(REGEX_URL, r"\g<1>lta-station:5000", value))
             if station.prip:
-                return re.sub(REGEX_URL, r"\g<1>prip-station:5000", value)
+                return re.sub(REGEX_DOMAIN, "prip-station", re.sub(REGEX_URL, r"\g<1>prip-station:5000", value))
             # No modification
             return value
 

--- a/services/staging/rs_server_staging/main.py
+++ b/services/staging/rs_server_staging/main.py
@@ -271,7 +271,6 @@ async def execute_process(req: Request, resource: str, data: ProcessMetadataMode
             data.inputs.items,
             data.inputs.collection.id,
             data.outputs["result"].id,
-            data.inputs.provider,
             app.extra["process_manager"],
             app.extra["dask_cluster"],
         ).execute()

--- a/services/staging/rs_server_staging/processors.py
+++ b/services/staging/rs_server_staging/processors.py
@@ -20,6 +20,7 @@ import time
 import uuid
 from datetime import datetime
 from typing import Union
+from urllib.parse import urlparse
 
 import requests
 from dask.distributed import CancelledError, Client, LocalCluster, as_completed
@@ -30,7 +31,7 @@ from pygeoapi.process.manager.postgresql import PostgreSQLManager
 from requests.auth import AuthBase
 from rs_server_common.authentication.authentication_to_external import (
     get_station_token,
-    load_external_auth_config_by_station_service,
+    load_external_auth_config_by_domain,
 )
 from rs_server_common.s3_storage_handler.s3_storage_handler import S3StorageHandler
 from rs_server_common.utils.logging import Logging
@@ -144,7 +145,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         input_collection: FeatureCollectionModel,
         collection: str,
         item: str,
-        provider: str,
         db_process_manager: PostgreSQLManager,
         cluster: LocalCluster,
     ):  # pylint: disable=super-init-not-called
@@ -157,7 +157,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             input_collection (FeatureCollectionModel): The input collection of RSPY features to process.
             collection (str): The name of the collection from the catalog to use.
             item (str): The specific item to process within the collection.
-            provider (str): The name of the provider offering the data for processing.
             db_process_manager (PostgreSQLManager): The pygeoapi Postgresql Manager used to track job execution
                 status and metadata.
             cluster (LocalCluster): The Dask LocalCluster instance used to manage distributed computation tasks.
@@ -173,7 +172,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             item_collection (FeatureCollectionModel): Holds the input collection of features.
             catalog_collection (str): Name of the catalog collection.
             catalog_item_name (str): Name of the specific item in the catalog being processed.
-            provider (str): The data provider for the current processing task.
             assets_info (list): Holds information about assets associated with the processing.
             tasks (list): List of tasks to be executed for processing.
             lock (threading.Lock): A threading lock to synchronize access to shared resources.
@@ -206,7 +204,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         self.item_collection: FeatureCollectionModel = input_collection
         self.catalog_collection: str = collection
         self.catalog_item_name: str = item
-        self.provider: str = provider
         self.assets_info: list = []
         self.tasks: list = []
         # Tasks finished
@@ -796,9 +793,21 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             self.logger.info("There are no assets to stage. Exiting....")
             return
 
+        # Determine the domain(s)
+        domains = list({urlparse(asset[0]).hostname for asset in self.assets_info})
+        self.logger.info("Staging from domain(s) {domains}")
+        if len(domains) > 1:
+            self.log_job_execution(
+                EStagingStatus.FAILED,
+                0,
+                detail="Staging from multiple domains is not supported yet",
+            )
+            return
+        domain = domains[0]
+
         # retrieve the token
         try:
-            external_auth_config = load_external_auth_config_by_station_service(self.provider.lower())
+            external_auth_config = load_external_auth_config_by_domain(domain)
             token = get_station_token(external_auth_config)
         except HTTPException as http_exception:
             self.logger.error(
@@ -807,8 +816,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             self.log_job_execution(
                 EStagingStatus.FAILED,
                 0,
-                detail="Failed to retrieve the token needed to connect to the external "
-                f"station {self.provider.lower()}",
+                detail=f"Failed to retrieve the token needed to connect to the external station {domain}",
             )
             return
 

--- a/services/staging/rs_server_staging/rspy_models.py
+++ b/services/staging/rs_server_staging/rspy_models.py
@@ -99,17 +99,15 @@ class InputModel(BaseModel):
     """Model for input data.
 
     This model encapsulates the input information, including a collection of features,
-    metadata, and the provider.
+    metadata.
 
     Attributes:
         collection (CollectionModel): The collection of metadata for the input.
         items (FeatureCollectionModel): A collection of features related to the input.
-        provider (str): The name or identifier of the data provider.
     """
 
     collection: CollectionModel
     items: FeatureCollectionModel
-    provider: str
 
 
 class OutputModel(BaseModel):

--- a/services/staging/tests/conftest.py
+++ b/services/staging/tests/conftest.py
@@ -140,7 +140,6 @@ def staging(mocker):
     mock_input_collection = mocker.Mock()
     mock_collection = "test_collection"
     mock_item = "test_item"
-    mock_provider = "cadip"
     mock_db = mocker.Mock()  # Mock for PostgreSQL Manager
     mock_cluster = mocker.Mock()  # Mock for LocalCluster
 
@@ -157,7 +156,6 @@ def staging(mocker):
         input_collection=mock_input_collection,
         collection=mock_collection,
         item=mock_item,
-        provider=mock_provider,
         db_process_manager=mock_db,
         cluster=mock_cluster,
     )

--- a/services/staging/tests/test_rspy_processor.py
+++ b/services/staging/tests/test_rspy_processor.py
@@ -964,11 +964,11 @@ class TestStagingMainExecution:
         # Simulate successful task preparation
         mocker.patch.object(staging_instance, "prepare_streaming_tasks", return_value=True)
         mock_dask_cluster_connect = mocker.patch.object(staging_instance, "dask_cluster_connect")
-        staging_instance.assets_info = ["some_asset"]
+        staging_instance.assets_info = [("https://cadip/some_asset", "some_asset")]
 
         # Simulate an exception in the token retrieval
         mocker.patch(
-            "rs_server_staging.processors.load_external_auth_config_by_station_service",
+            "rs_server_staging.processors.load_external_auth_config_by_domain",
             return_value=mocker.Mock(),
         )
         mocker.patch(
@@ -1007,7 +1007,7 @@ class TestStagingMainExecution:
         mock_manage_dask_tasks = mocker.patch.object(staging_instance, "manage_dask_tasks_results")
         # Mock token retrieval
         mocker.patch(
-            "rs_server_staging.processors.load_external_auth_config_by_station_service",
+            "rs_server_staging.processors.load_external_auth_config_by_domain",
             return_value=mocker.Mock(),
         )
         mocker.patch("rs_server_staging.processors.get_station_token", return_value="mock_token")
@@ -1046,19 +1046,19 @@ class TestStagingMainExecution:
         mock_manage_dask_tasks = mocker.patch.object(staging_instance, "manage_dask_tasks_results")
         # Mock token retrieval
         mocker.patch(
-            "rs_server_staging.processors.load_external_auth_config_by_station_service",
+            "rs_server_staging.processors.load_external_auth_config_by_domain",
             return_value=mocker.Mock(),
         )
 
         mocker.patch(
-            "rs_server_staging.processors.load_external_auth_config_by_station_service",
+            "rs_server_staging.processors.load_external_auth_config_by_domain",
             return_value="mock_external_auth_config",
         )
         # Mock the external auth configuration
         mock_external_auth_config = mocker.Mock()
         mock_external_auth_config.trusted_domains = ["test_trusted.example"]  # Set the trusted_domains member
         mocker.patch(
-            "rs_server_staging.processors.load_external_auth_config_by_station_service",
+            "rs_server_staging.processors.load_external_auth_config_by_domain",
             return_value=mock_external_auth_config,
         )
         mocker.patch("rs_server_staging.processors.get_station_token", return_value="mock_token")


### PR DESCRIPTION
The current Staging implementation asks for a "provider" parameter that was not asked for in the user stories.

This PR removes it as we don't want to have to provide this information. The wanted behavior is to retrieve authentication configuration from domain, as described in RSPY-350 (not yet implemented).

Requires https://github.com/RS-PYTHON/rs-demo/pull/83