### PR TITLE
Use job status from OGC Process API

### DIFF
--- a/services/staging/rs_server_staging/main.py
+++ b/services/staging/rs_server_staging/main.py
@@ -46,6 +46,9 @@ from starlette.status import (
     HTTP_503_SERVICE_UNAVAILABLE,
 )
 
+# flake8: noqa: F401
+# pylint: disable=W0611
+from . import staging_job_status  # DON'T REMOVE (needed for SQLAlchemy)
 from .rspy_models import ProcessMetadataModel
 
 logger = Logging.default(__name__)
@@ -116,7 +119,7 @@ def init_db(pause: int = 3, timeout: int | None = None) -> PostgreSQLManager:
 
     This function constructs the database URL using environment variables for PostgreSQL
     credentials, host, port, and database name. It then creates an SQLAlchemy engine and
-    registers the ENUM type EStagingStatus and the 'job' tables if they don't already exist.
+    registers the ENUM type JobStatus and the 'job' tables if they don't already exist.
 
     Environment Variables:
         - POSTGRES_USER: Username for database authentication.

--- a/services/staging/rs_server_staging/processors.py
+++ b/services/staging/rs_server_staging/processors.py
@@ -28,6 +28,7 @@ from dask_gateway import Gateway, JupyterHubAuth
 from fastapi import HTTPException
 from pygeoapi.process.base import BaseProcessor
 from pygeoapi.process.manager.postgresql import PostgreSQLManager
+from pygeoapi.util import JobStatus
 from requests.auth import AuthBase
 from rs_server_common.authentication.authentication_to_external import (
     get_station_token,
@@ -39,7 +40,6 @@ from starlette.datastructures import Headers
 from starlette.requests import Request
 
 from .rspy_models import Feature, FeatureCollectionModel
-from .staging_job_status import EStagingStatus
 
 
 # Custom authentication class
@@ -197,7 +197,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         self.detail: str = "Processing Unit was created"
         self.progress: float = 0.0
         self.db_process_manager = db_process_manager
-        self.status = EStagingStatus.QUEUED
+        self.status = JobStatus.accepted
         self.create_job_execution()
         #################
         # Inputs section
@@ -229,10 +229,9 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         Returns:
             dict: A dictionary containing the job ID and a status message indicating the job
                 has started.
-                Example: {"started": <job_id>}
+                Example: {"running": <job_id>}
 
         Logs:
-            EStagingStatus.CREATED: Logs the creation of a new processing job.
             Error: Logs an error if connecting to the catalog service fails.
 
         Raises:
@@ -243,11 +242,11 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         # Check if item collection is provided
         if not self.item_collection or not hasattr(self.item_collection, "features"):
             self.log_job_execution(
-                EStagingStatus.FINISHED,
+                JobStatus.successful,
                 0,
                 detail="No valid items were provided in the input for staging",
             )
-            return {"finished": self.job_id}
+            return {JobStatus.successful.value: self.job_id}
 
         # Filter out features with no assets
         self.item_collection.features = [feature for feature in self.item_collection.features if feature.assets]
@@ -255,27 +254,25 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         # Check if any features with assets remain
         if not self.item_collection.features:
             self.log_job_execution(
-                EStagingStatus.FINISHED,
+                JobStatus.successful,
                 0,
                 detail="No items with assets were found in the input for staging",
             )
-            return {"finished": self.job_id}
+            return {JobStatus.successful.value: self.job_id}
 
-        # set the CREATED status for the job
-        self.log_job_execution(EStagingStatus.CREATED)
         # Execution section
         if not await self.check_catalog():
             self.logger.error(
                 f"Failed to start the staging process. Checking the collection '{self.catalog_collection}' failed !",
             )
             self.log_job_execution(
-                EStagingStatus.FAILED,
+                JobStatus.failed,
                 0,
                 detail="Failed to start the staging process. "
                 f"Checking the collection '{self.catalog_collection}' failed !",
             )
-            return {"failed": self.job_id}
-        self.log_job_execution(EStagingStatus.STARTED, 0, detail="Successfully searched catalog")
+            return {JobStatus.failed.value: self.job_id}
+        self.log_job_execution(JobStatus.running, 0, detail="Successfully searched catalog")
         # Start execution
         loop = asyncio.get_event_loop()
         if loop.is_running():
@@ -285,7 +282,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             # If the loop is not running, run it until complete
             loop.run_until_complete(self.process_rspy_features())
 
-        return {"started": self.job_id}
+        return {JobStatus.running.value: self.job_id}
 
     def create_job_execution(self):
         """
@@ -303,12 +300,12 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
 
         Notes:
             - The `self.tracker` is expected to have an `insert` method to store the job information.
-            - The status is converted to JSON using `EStagingStatus.to_json()`.
+            - The status is converted to JSON using `JobStatus.to_json()`.
 
         """
         job_metadata = {
             "identifier": self.job_id,
-            "status": self.status.value.upper(),
+            "status": self.status.value,
             "progress": self.progress,
             "detail": self.detail,
         }
@@ -316,7 +313,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
 
     def log_job_execution(
         self,
-        status: Union[EStagingStatus, None] = None,
+        status: Union[JobStatus, None] = None,
         progress: Union[float, None] = None,
         detail: Union[str, None] = None,
     ):
@@ -328,7 +325,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         self.detail = detail if detail else self.detail
 
         update_data = {
-            "status": self.status.value.upper(),
+            "status": self.status.value,
             "progress": self.progress,
             "detail": self.detail,
             "updated_at": datetime.now(),  # Update updated_at each time a change is made
@@ -384,7 +381,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             RuntimeError,
         ) as exc:
             self.logger.error(f"Failed to search catalog: {exc}")
-            self.log_job_execution(EStagingStatus.FAILED, 0, detail=f"Failed to search catalog: {exc}")
+            self.log_job_execution(JobStatus.failed, 0, detail=f"Failed to search catalog: {exc}")
             return False
 
     def create_streaming_list(self, catalog_response: dict):
@@ -553,7 +550,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
                 task.result()  # This will raise the exception from the task if it failed
                 self.tasks_finished += 1
                 self.log_job_execution(
-                    EStagingStatus.IN_PROGRESS,
+                    JobStatus.running,
                     round((self.tasks_finished * 100 / len(self.tasks)), 2),
                     detail="In progress",
                 )
@@ -572,7 +569,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
                     timeout -= 1
                 # Update status for the job
                 self.log_job_execution(
-                    EStagingStatus.FAILED,
+                    JobStatus.failed,
                     None,
                     detail=f"At least one of the tasks failed: {task_e}",
                 )
@@ -585,7 +582,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             if not self.publish_rspy_feature(feature):
                 # cleanup
                 self.log_job_execution(
-                    EStagingStatus.FAILED,
+                    JobStatus.failed,
                     None,
                     detail=f"The item {feature.id} couldn't be " "published in the catalog. Cleaning up",
                 )
@@ -596,7 +593,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
                 return
             published_featurs_ids.append(feature.id)
         # Update status once all features are processed
-        self.log_job_execution(EStagingStatus.FINISHED, 100, detail="Finished")
+        self.log_job_execution(JobStatus.successful, 100, detail="Finished")
         self.logger.info("Tasks monitoring finished")
 
     def dask_cluster_connect(self):
@@ -786,10 +783,10 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         # Process each feature by initiating the streaming download of its assets to the final bucket.
         for feature in self.stream_list:
             if not self.prepare_streaming_tasks(feature):
-                self.log_job_execution(EStagingStatus.FAILED, 0, detail="Unable to create tasks for the Dask cluster")
+                self.log_job_execution(JobStatus.failed, 0, detail="Unable to create tasks for the Dask cluster")
                 return
         if not self.assets_info:
-            self.log_job_execution(EStagingStatus.FINISHED, 100, detail="Finished without processing any tasks")
+            self.log_job_execution(JobStatus.successful, 100, detail="Finished without processing any tasks")
             self.logger.info("There are no assets to stage. Exiting....")
             return
 
@@ -798,7 +795,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         self.logger.info("Staging from domain(s) {domains}")
         if len(domains) > 1:
             self.log_job_execution(
-                EStagingStatus.FAILED,
+                JobStatus.failed,
                 0,
                 detail="Staging from multiple domains is not supported yet",
             )
@@ -814,7 +811,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
                 f"Failed to retrieve the token needed to connect to the external station: {http_exception}",
             )
             self.log_job_execution(
-                EStagingStatus.FAILED,
+                JobStatus.failed,
                 0,
                 detail=f"Failed to retrieve the token needed to connect to the external station {domain}",
             )
@@ -822,16 +819,15 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
 
         # connect to the dask cluster
         try:
-
             dask_client = self.dask_cluster_connect()
             self.submit_tasks_to_dask_cluster(token, external_auth_config.trusted_domains, dask_client)
         except RuntimeError as re:
-            self.log_job_execution(EStagingStatus.FAILED, 0, detail=f"{re}")
+            self.log_job_execution(JobStatus.failed, 0, detail=f"{re}")
             self.logger.error("Failed to start the staging process")
             return
 
-        # Set the status to IN_PROGRESS for the job
-        self.log_job_execution(EStagingStatus.IN_PROGRESS, 0, detail="Sending tasks to the dask cluster")
+        # Set the status to running for the job
+        self.log_job_execution(JobStatus.running, 0, detail="Sending tasks to the dask cluster")
 
         # starting another thread for managing the dask callbacks
         self.logger.debug("Starting tasks monitoring thread")
@@ -839,7 +835,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             await asyncio.to_thread(self.manage_dask_tasks_results, dask_client)
         except Exception as e:  # pylint: disable=broad-exception-caught
             self.logger.debug(f"Error from tasks monitoring thread: {e}")
-            self.log_job_execution(EStagingStatus.FAILED, 0, detail=f"Error from tasks monitoring thread: {e}")
+            self.log_job_execution(JobStatus.failed, 0, detail=f"Error from tasks monitoring thread: {e}")
 
         # cleanup by disconnecting the dask client
         self.assets_info = []
@@ -870,7 +866,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
 
         Logging:
             - Logs an error message with details if the request fails.
-            - Logs the job status as `EStagingStatus.FAILED` if the feature publishing fails.
+            - Logs the job status as `JobStatus.failed` if the feature publishing fails.
             - Calls `self.delete_files_from_bucket()` to clean up related files in case of failure.
         """
         # Publish feature to catalog

--- a/services/staging/rs_server_staging/staging_job_status.py
+++ b/services/staging/rs_server_staging/staging_job_status.py
@@ -16,9 +16,9 @@
 
 from __future__ import annotations
 
-import enum
 from threading import Lock
 
+from pygeoapi.util import JobStatus
 from rs_server_common.db import Base
 from sqlalchemy import Column, DateTime, Enum, Float, String, func, orm
 
@@ -27,33 +27,13 @@ from sqlalchemy import Column, DateTime, Enum, Float, String, func, orm
 # Ignore pylint and mypy false positive errors on sqlalchemy
 
 
-class EStagingStatus(str, enum.Enum):
-    """
-    Staging status enumeration.
-    """
-
-    QUEUED = "queued"  # Request received, processor will start soon
-    CREATED = "created"  # Processor has been initialised
-    STARTED = "started"  # Processor execution has started
-    IN_PROGRESS = "in_progress"  # Processor execution is in progress
-    STOPPED = "stopped"
-    FAILED = "failed"
-    FINISHED = "finished"
-    PAUSED = "paused"
-    RESUMED = "resumed"
-    CANCELLED = "cancelled"
-
-    def __str__(self):
-        return self.value
-
-
 class StagingJobStatus(Base):  # pylint: disable=too-few-public-methods
     """Abstract implementation of SQLAlchemy Base"""
 
     __tablename__ = "jobs"
 
     identifier = Column(String, primary_key=True, unique=True, index=True)
-    status = Column(Enum(EStagingStatus), nullable=False)
+    status = Column(Enum(JobStatus), nullable=False)
     progress = Column(Float, server_default="0.0")
     # Pylint issue with func.now, check this: https://github.com/sqlalchemy/sqlalchemy/issues/9189
     created_at = Column(DateTime, server_default=func.now())  # pylint: disable=not-callable

--- a/services/staging/tests/conftest.py
+++ b/services/staging/tests/conftest.py
@@ -98,7 +98,7 @@ def dbj_():
     return [
         {
             "identifier": "job_1",
-            "status": "started",
+            "status": "running",
             "progress": 0.0,
             "detail": TEST_DETAIL,
             "created_at": str(datetime(2024, 1, 1, 12, 0, 0)),
@@ -106,7 +106,7 @@ def dbj_():
         },
         {
             "identifier": "job_2",
-            "status": "in_progress",
+            "status": "running",
             "progress": 55.0,
             "detail": TEST_DETAIL,
             "created_at": str(datetime(2024, 1, 2, 12, 0, 0)),
@@ -114,7 +114,7 @@ def dbj_():
         },
         {
             "identifier": "job_3",
-            "status": "paused",
+            "status": "running",
             "progress": 15.0,
             "detail": TEST_DETAIL,
             "created_at": str(datetime(2024, 1, 3, 12, 0, 0)),
@@ -122,7 +122,7 @@ def dbj_():
         },
         {
             "identifier": "job_4",
-            "status": "finished",
+            "status": "successful",
             "progress": 100.0,
             "detail": TEST_DETAIL,
             "created_at": str(datetime(2024, 1, 4, 12, 0, 0)),

--- a/services/staging/tests/test_rspy_processor.py
+++ b/services/staging/tests/test_rspy_processor.py
@@ -24,29 +24,12 @@ import pytest
 import requests
 from dask_gateway import Gateway
 from fastapi import HTTPException
+from pygeoapi.util import JobStatus
 from rs_server_staging.processors import TokenAuth, streaming_task
-from rs_server_staging.staging_job_status import EStagingStatus
 
 # pylint: disable=undefined-variable
 # pylint: disable=no-member
 # pylint: disable=too-many-lines
-
-
-class TestProcessorStatus:  # pylint: disable=too-few-public-methods
-    """Class for tests of EStagingStatus enum"""
-
-    def test_str_method(self):
-        """Test the __str__ method of EStagingStatus."""
-        assert str(EStagingStatus.QUEUED) == "queued"
-        assert str(EStagingStatus.FINISHED) == "finished"
-        assert str(EStagingStatus.FAILED) == "failed"
-        assert str(EStagingStatus.CREATED) == "created"
-        assert str(EStagingStatus.STARTED) == "started"
-        assert str(EStagingStatus.IN_PROGRESS) == "in_progress"
-        assert str(EStagingStatus.STOPPED) == "stopped"
-        assert str(EStagingStatus.PAUSED) == "paused"
-        assert str(EStagingStatus.RESUMED) == "resumed"
-        assert str(EStagingStatus.CANCELLED) == "cancelled"
 
 
 class TestTokenAuth:
@@ -161,13 +144,13 @@ class TestStaging:
         result = await staging_instance.execute()
 
         # Assertions
-        assert mock_log_job.call_count == 2
+        assert mock_log_job.call_count == 1
         mock_log_job.assert_has_calls(
-            [call(EStagingStatus.CREATED), call(EStagingStatus.STARTED, 0, detail="Successfully searched catalog")],
+            [call(JobStatus.running, 0, detail="Successfully searched catalog")],
         )
         mock_check_catalog.assert_called_once()
         mock_process_rspy.assert_called_once()  # Ensures processing is scheduled
-        assert result == {"started": staging_instance.job_id}
+        assert result == {"running": staging_instance.job_id}
 
     @pytest.mark.asyncio
     async def test_execute_fails_in_checking_catalog(self, mocker, staging_instance, asyncio_loop):
@@ -185,12 +168,11 @@ class TestStaging:
         result = await staging_instance.execute()
 
         # Assertions
-        assert mock_log_job.call_count == 2
+        assert mock_log_job.call_count == 1
         mock_log_job.assert_has_calls(
             [
-                call(EStagingStatus.CREATED),
                 call(
-                    EStagingStatus.FAILED,
+                    JobStatus.failed,
                     0,
                     detail="Failed to start the staging process. "
                     f"Checking the collection '{staging_instance.catalog_collection}' failed !",
@@ -218,11 +200,11 @@ class TestStaging:
 
         # Assertions
         mock_log_job.assert_called_once_with(
-            EStagingStatus.FINISHED,
+            JobStatus.successful,
             0,
             detail="No valid items were provided in the input for staging",
         )
-        assert result == {"finished": staging_instance.job_id}
+        assert result == {"successful": staging_instance.job_id}
 
     def test_create_job_execution(self, staging_instance, mocker):
         """Test the create_job_execution method of the Staging class.
@@ -241,7 +223,7 @@ class TestStaging:
 
         # Set job attributes needed for create_job_execution
         staging_instance.job_id = "12345"
-        staging_instance.status = EStagingStatus.QUEUED
+        staging_instance.status = JobStatus.accepted
         staging_instance.progress = 0
         staging_instance.detail = "Job is starting."
 
@@ -252,7 +234,7 @@ class TestStaging:
         mock_db_process_manager.add_job.assert_called_once_with(
             {
                 "identifier": "12345",
-                "status": EStagingStatus.QUEUED.value.upper(),
+                "status": JobStatus.accepted.value,
                 "progress": 0,
                 "detail": "Job is starting.",
             },
@@ -274,7 +256,7 @@ class TestStaging:
 
         staging_instance.db_process_manager = mock_db_process_manager
         staging_instance.job_id = "12345"
-        staging_instance.status = EStagingStatus.QUEUED
+        staging_instance.status = JobStatus.accepted
         staging_instance.progress = 0
         staging_instance.detail = "Job is starting."
 
@@ -293,7 +275,7 @@ class TestStaging:
         mock_update_job.assert_called_once_with(
             staging_instance.job_id,
             {
-                "status": EStagingStatus.QUEUED.value.upper(),
+                "status": JobStatus.accepted.value,
                 "progress": 0,
                 "detail": "Job is starting.",
                 "updated_at": fake_now,
@@ -305,7 +287,7 @@ class TestStaging:
 
         # Call log_job_execution to test status update with custom attrs
         staging_instance.log_job_execution(
-            status=EStagingStatus.IN_PROGRESS,
+            status=JobStatus.running,
             progress=50.0,
             detail="Job is halfway done.",
         )
@@ -314,7 +296,7 @@ class TestStaging:
         mock_update_job.assert_called_once_with(
             staging_instance.job_id,
             {
-                "status": EStagingStatus.IN_PROGRESS.value.upper(),
+                "status": JobStatus.running.value,
                 "progress": 50.0,
                 "detail": "Job is halfway done.",
                 "updated_at": fake_now,
@@ -430,7 +412,7 @@ class TestStagingCatalog:
             # Assert that create_streaming_list was not called during failure
             mock_create_streaming_list.assert_not_called()
             mock_log_job_execution.assert_called_once_with(
-                EStagingStatus.FAILED,
+                JobStatus.failed,
                 0,
                 detail=f"Failed to search catalog: {get_err_msg}",
             )
@@ -450,7 +432,7 @@ class TestStagingCatalog:
         # Call the method under test
         await staging_instance.check_catalog()
         mock_log_job_execution.assert_called_once_with(
-            EStagingStatus.FAILED,
+            JobStatus.failed,
             0,
             detail=f"Failed to search catalog: {err_msg}",
         )
@@ -598,7 +580,7 @@ class TestStagingTaskFailure:  # pylint: disable=too-few-public-methods
         mock_task2 = mocker.Mock()
         mock_task2.done.return_value = True  # Simulate a completed task
         mock_task2.key = "task2"
-        mock_task2.status = "finished"
+        mock_task2.status = "successful"
 
         # Mock the CancelledError
         mock_cancelled_error = CancelledError("Task already cancelled")
@@ -850,9 +832,9 @@ class TestStagingMainExecution:
 
         staging_instance.manage_dask_tasks_results(client)
 
-        # mock_log_job.assert_any_call(EStagingStatus.IN_PROGRESS, None, detail='In progress')
+        # mock_log_job.assert_any_call(JobStatus.running, None, detail='In progress')
         # Check that status was updated 3 times during execution, 1 time for each task, and 1 time with FINISH
-        mock_log_job.assert_any_call(EStagingStatus.FINISHED, 100, detail="Finished")
+        mock_log_job.assert_any_call(JobStatus.successful, 100, detail="Finished")
         assert mock_log_job.call_count == 3
         # Check that feature publish method was called.
         mock_publish_feature.assert_called()
@@ -879,7 +861,7 @@ class TestStagingMainExecution:
         mock_task_failure.assert_called()  # handle_task_failure called once
         mock_delete_file_from_bucket.assert_called()  # Bucket removal called once
         # logger set status to failed
-        mock_log_job.assert_called_once_with(EStagingStatus.FAILED, None, detail="At least one of the tasks failed: ")
+        mock_log_job.assert_called_once_with(JobStatus.failed, None, detail="At least one of the tasks failed: ")
         # Features are not published here.
         mock_publish_feature.assert_not_called()
 
@@ -907,7 +889,7 @@ class TestStagingMainExecution:
         staging_instance.manage_dask_tasks_results(client)
 
         mock_log_job.assert_any_call(
-            EStagingStatus.FAILED,
+            JobStatus.failed,
             None,
             detail=f"The item {task1.id} couldn't be " "published in the catalog. Cleaning up",
         )
@@ -935,7 +917,7 @@ class TestStagingMainExecution:
         await staging_instance.process_rspy_features()
 
         # Ensure the task preparation failed, and method returned early
-        mock_log_job.assert_called_with(EStagingStatus.FAILED, 0, detail="Unable to create tasks for the Dask cluster")
+        mock_log_job.assert_called_with(JobStatus.failed, 0, detail="Unable to create tasks for the Dask cluster")
 
     @pytest.mark.asyncio
     async def test_process_rspy_features_empty_stream(self, mocker, staging_instance):
@@ -952,7 +934,7 @@ class TestStagingMainExecution:
         await staging_instance.process_rspy_features()
 
         # Assert initial logging and job execution calls
-        mock_log_job.assert_called_with(EStagingStatus.FINISHED, 100, detail="Finished without processing any tasks")
+        mock_log_job.assert_called_with(JobStatus.successful, 100, detail="Finished without processing any tasks")
 
     @pytest.mark.asyncio
     async def test_process_rspy_features_token_failure(self, mocker, staging_instance):
@@ -984,7 +966,7 @@ class TestStagingMainExecution:
             "Failed to retrieve the token needed to connect to the external station: 404: Token error",
         )
         mock_log_job.assert_called_once_with(
-            EStagingStatus.FAILED,
+            JobStatus.failed,
             0,
             detail="Failed to retrieve the token needed to connect to the external station cadip",
         )
@@ -1023,7 +1005,7 @@ class TestStagingMainExecution:
         await staging_instance.process_rspy_features()
 
         # Verify log_job_execution is called with the error details
-        mock_log_job.assert_called_once_with(EStagingStatus.FAILED, 0, detail="Dask cluster client failed")
+        mock_log_job.assert_called_once_with(JobStatus.failed, 0, detail="Dask cluster client failed")
         mock_logger.error.assert_called_once_with("Failed to start the staging process")
 
         # Verify that the task submission and monitoring thread are not executed

--- a/services/staging/tests/test_staging.py
+++ b/services/staging/tests/test_staging.py
@@ -34,7 +34,7 @@ from starlette.status import (
 expected_jobs_test = [
     {
         "identifier": "job_1",
-        "status": "started",
+        "status": "running",
         "progress": 0.0,
         "detail": "Test detail",
         "created_at": str(datetime(2024, 1, 1, 12, 0, 0)),
@@ -42,7 +42,7 @@ expected_jobs_test = [
     },
     {
         "identifier": "job_2",
-        "status": "in_progress",
+        "status": "running",
         "progress": 55.0,
         "detail": "Test detail",
         "created_at": str(datetime(2024, 1, 2, 12, 0, 0)),
@@ -50,7 +50,7 @@ expected_jobs_test = [
     },
     {
         "identifier": "job_3",
-        "status": "paused",
+        "status": "running",
         "progress": 15.0,
         "detail": "Test detail",
         "created_at": str(datetime(2024, 1, 3, 12, 0, 0)),
@@ -58,7 +58,7 @@ expected_jobs_test = [
     },
     {
         "identifier": "job_4",
-        "status": "finished",
+        "status": "successful",
         "progress": 100.0,
         "detail": "Test detail",
         "created_at": str(datetime(2024, 1, 4, 12, 0, 0)),
@@ -66,7 +66,7 @@ expected_jobs_test = [
     },
     {
         "identifier": "non_existing",
-        "status": "finished",
+        "status": "successful",
         "progress": 100.0,
         "detail": "Test detail",
         "created_at": "unknown",
@@ -172,7 +172,7 @@ async def test_get_jobs_endpoint(mocker, set_db_env_var, staging_client):  # pyl
     mock_jobs = [
         {
             "identifier": "job_1",
-            "status": "completed",
+            "status": "successful",
             "progress": 100.0,
             "detail": "Test detail",
             "created_at": str(datetime(2024, 1, 1, 12, 0, 0)),
@@ -180,7 +180,7 @@ async def test_get_jobs_endpoint(mocker, set_db_env_var, staging_client):  # pyl
         },
         {
             "identifier": "job_2",
-            "status": "in-progress",
+            "status": "running",
             "progress": 90.25,
             "detail": "Test detail",
             "created_at": str(datetime(2024, 1, 2, 12, 0, 0)),


### PR DESCRIPTION
In RSPY-321 I asked to create the staging application as an [OGC API Processes Part 1 Core](https://ogcapi.ogc.org/processes/overview.html) implementation based on pygeoapi.

For job statuses, it means using the statuses defined in the specification instead of a custom list of ours.

This PR fixes to use pygeoapi job statuses.

Requires https://github.com/RS-PYTHON/rs-demo/pull/85

Followed by #860