### PR TITLE
Staging: use pygeoapi processor signature

### DIFF
--- a/services/common/rs_server_common/s3_storage_handler/s3_storage_handler.py
+++ b/services/common/rs_server_common/s3_storage_handler/s3_storage_handler.py
@@ -112,7 +112,12 @@ class CustomSessionRedirect(requests.Session):
     """
 
     def __init__(self, trusted_domains=list[str] | None):
-        """Initialize the CustomSession instance."""
+        """
+        Initialize the CustomSession instance.
+
+        Args:
+            trusted_domains (list): List of allowed hosts for redirection in case of change of protocol (HTTP <> HTTPS).
+        """
         super().__init__()
         self.trusted_domains: list[str] = trusted_domains or []  # List of allowed hosts for redirection
 
@@ -871,6 +876,7 @@ retried for %s times. Aborting",
 
         Args:
             stream_url (str): The URL of the file to be streamed and uploaded.
+            trusted_domains (list): List of allowed hosts for redirection in case of change of protocol (HTTP <> HTTPS).
             auth (Any): Authentication credentials for the HTTP request (if required).
             bucket (str): The name of the target S3 bucket.
             key (str): The S3 object key (file path) to store the streamed file.

--- a/services/staging/rs_server_staging/main.py
+++ b/services/staging/rs_server_staging/main.py
@@ -269,14 +269,12 @@ async def execute_process(req: Request, resource: str, data: ProcessMetadataMode
     processor_name = api.config["resources"][resource]["processor"]["name"]
     if processor_name in processors:
         processor = processors[processor_name]
-        status = await processor(
+        _, status = await processor(
             req,
-            data.inputs.items,
-            data.inputs.collection.id,
             data.outputs["result"].id,
             app.extra["process_manager"],
             app.extra["dask_cluster"],
-        ).execute()
+        ).execute(data.inputs.dict())
         return JSONResponse(status_code=HTTP_200_OK, content={"status": status})
 
     raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"Processor '{processor_name}' not found")

--- a/services/staging/rs_server_staging/processors.py
+++ b/services/staging/rs_server_staging/processors.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Base RSPY Stagging processor."""
+"""RSPY Staging processor."""
 
 import asyncio  # for handling asynchronous tasks
-import json
 import os
 import time
 import uuid
 from datetime import datetime
+from json import JSONDecodeError
 from typing import Union
 from urllib.parse import urlparse
 
@@ -30,6 +30,7 @@ from pygeoapi.process.base import BaseProcessor
 from pygeoapi.process.manager.postgresql import PostgreSQLManager
 from pygeoapi.util import JobStatus
 from requests.auth import AuthBase
+from requests.exceptions import RequestException
 from rs_server_common.authentication.authentication_to_external import (
     get_station_token,
     load_external_auth_config_by_domain,
@@ -85,6 +86,7 @@ def streaming_task(product_url: str, trusted_domains: list[str], auth: str, buck
 
     Args:
         product_url (str): The URL of the product to download.
+        trusted_domains (list): List of allowed hosts for redirection in case of change of protocol (HTTP <> HTTPS).
         auth (str): The authentication token or credentials required for the download.
         s3_file (str): The destination path/key in the S3 bucket where the file will be uploaded.
 
@@ -142,8 +144,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
     def __init__(
         self,
         credentials: Request,
-        input_collection: FeatureCollectionModel,
-        collection: str,
         item: str,
         db_process_manager: PostgreSQLManager,
         cluster: LocalCluster,
@@ -154,8 +154,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
 
         Args:
             credentials (Headers): Authentication headers used for requests.
-            input_collection (FeatureCollectionModel): The input collection of RSPY features to process.
-            collection (str): The name of the collection from the catalog to use.
             item (str): The specific item to process within the collection.
             db_process_manager (PostgreSQLManager): The pygeoapi Postgresql Manager used to track job execution
                 status and metadata.
@@ -169,8 +167,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             job_id (str): A unique identifier for the processing job, generated using UUID.
             message (str): Status message describing the current state of the processing unit.
             progress (int): Integer tracking the progress of the current job.
-            item_collection (FeatureCollectionModel): Holds the input collection of features.
-            catalog_collection (str): Name of the catalog collection.
             catalog_item_name (str): Name of the specific item in the catalog being processed.
             assets_info (list): Holds information about assets associated with the processing.
             tasks (list): List of tasks to be executed for processing.
@@ -184,7 +180,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         #################
         # Locals
         self.headers: Headers = credentials.headers
-        self.stream_list: list = []
+        self.stream_list: list[Feature] = []
         #################
         # Env section
         self.catalog_url: str = os.environ.get(
@@ -201,8 +197,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         self.create_job_execution()
         #################
         # Inputs section
-        self.item_collection: FeatureCollectionModel = input_collection
-        self.catalog_collection: str = collection
         self.catalog_item_name: str = item
         self.assets_info: list = []
         self.tasks: list = []
@@ -213,7 +207,11 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         self.catalog_bucket = os.environ.get("RSPY_CATALOG_BUCKET", "rs-cluster-catalog")
 
     # Override from BaseProcessor, execute is async in RSPYProcessor
-    async def execute(self):  # pylint: disable=arguments-differ, invalid-overridden-method
+    async def execute(
+        self,
+        data: dict,
+        outputs: dict | None = None,  # pylint: disable=unused-argument
+    ) -> tuple[str, dict]:
         """
         Asynchronously execute the RSPY staging process, starting with a catalog check and
         proceeding to feature processing if the check succeeds.
@@ -226,10 +224,14 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         If the current event loop is running, the feature processing task is scheduled asynchronously.
         Otherwise, the event loop runs until the processing task is complete.
 
+        Args:
+            data (dict): input data that the process needs in order to execute
+            outputs (dict | list): not used
+
         Returns:
-            dict: A dictionary containing the job ID and a status message indicating the job
-                has started.
-                Example: {"running": <job_id>}
+            tuple: tuple of MIME type and process response (dictionary containing the job ID and a
+                status message).
+                Example: ("application/json", {"running": <job_id>})
 
         Logs:
             Error: Logs an error if connecting to the catalog service fails.
@@ -238,51 +240,52 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             None: This method doesn't raise any exceptions directly but logs errors if the
                 catalog check fails.
         """
+        self.logger.debug(f"Executing staging processor for {data}")
+        item_collection: FeatureCollectionModel | None = (
+            FeatureCollectionModel.parse_obj(data["items"]) if "items" in data else None
+        )
+        catalog_collection: str = data["collection"]["id"]
         # Check for the proper input
         # Check if item collection is provided
-        if not self.item_collection or not hasattr(self.item_collection, "features"):
-            self.log_job_execution(
+        if not item_collection or not hasattr(item_collection, "features"):
+            return self.log_job_execution(
                 JobStatus.successful,
                 0,
-                message="No valid items were provided in the input for staging",
+                "No valid items were provided in the input for staging",
             )
-            return {JobStatus.successful.value: self.job_id}
 
         # Filter out features with no assets
-        self.item_collection.features = [feature for feature in self.item_collection.features if feature.assets]
+        item_collection.features = [feature for feature in item_collection.features if feature.assets]
 
         # Check if any features with assets remain
-        if not self.item_collection.features:
-            self.log_job_execution(
+        if not item_collection.features:
+            return self.log_job_execution(
                 JobStatus.successful,
                 0,
-                message="No items with assets were found in the input for staging",
+                "No items with assets were found in the input for staging",
             )
-            return {JobStatus.successful.value: self.job_id}
 
         # Execution section
-        if not await self.check_catalog():
-            self.logger.error(
-                f"Failed to start the staging process. Checking the collection '{self.catalog_collection}' failed !",
-            )
-            self.log_job_execution(
+        if not await self.check_catalog(catalog_collection, item_collection.features):
+            return self.log_job_execution(
                 JobStatus.failed,
                 0,
-                message="Failed to start the staging process. "
-                f"Checking the collection '{self.catalog_collection}' failed !",
+                f"Failed to start the staging process. Checking the collection '{catalog_collection}' failed !",
             )
-            return {JobStatus.failed.value: self.job_id}
-        self.log_job_execution(JobStatus.running, 0, message="Successfully searched catalog")
+        self.log_job_execution(JobStatus.running, 0, "Successfully searched catalog")
         # Start execution
         loop = asyncio.get_event_loop()
         if loop.is_running():
             # If the loop is running, schedule the async function
-            asyncio.create_task(self.process_rspy_features())
+            asyncio.create_task(self.process_rspy_features(catalog_collection))
         else:
             # If the loop is not running, run it until complete
-            loop.run_until_complete(self.process_rspy_features())
+            loop.run_until_complete(self.process_rspy_features(catalog_collection))
 
-        return {JobStatus.running.value: self.job_id}
+        return self._get_execute_result()
+
+    def _get_execute_result(self) -> tuple[str, dict]:
+        return "application/json", {self.status.value: self.job_id}
 
     def create_job_execution(self):
         """
@@ -315,10 +318,22 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
     def log_job_execution(
         self,
         status: Union[JobStatus, None] = None,
-        progress: Union[float, None] = None,
+        progress: Union[int, None] = None,
         message: Union[str, None] = None,
-    ):
-        """Method used to log progress into db."""
+    ) -> tuple[str, dict]:
+        """
+        Method used to log progress into db.
+
+        Args:
+            status (JobStatus): new job status
+            progress (int): new job progress (percentage)
+            message (str): new job current information message
+
+        Returns:
+            tuple: tuple of MIME type and process response (dictionary containing the job ID and a
+                status message).
+                Example: ("application/json", {"running": <job_id>})
+        """
         # Update both runtime and db status and progress
 
         self.status = status if status else self.status
@@ -331,15 +346,27 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             "message": self.message,
             "updated": datetime.now(),  # Update updated each time a change is made
         }
+        if status == JobStatus.failed:
+            self.logger.error(f"Updating failed job {self.job_id}: {update_data}")
+        else:
+            self.logger.info(f"Updating job {self.job_id}: {update_data}")
         self.db_process_manager.update_job(self.job_id, update_data)
+        return self._get_execute_result()
 
-    async def check_catalog(self):
+    async def check_catalog(self, catalog_collection: str, features: list[Feature]) -> bool:
         """
         Method used to check RSPY catalog if a feature from input_collection is already published.
+
+        Args:
+            catalog_collection (str): Name of the catalog collection.
+            features (list): list of features to process.
+
+        Returns:
+            bool: True in case of success, False otherwise
         """
         # Set the filter containing the item ids to be inserted
         # Get each feature id and create /catalog/search argument
-        ids = [feature.id for feature in self.item_collection.features]
+        ids = [feature.id for feature in features]
         stry = []
         for id_ in ids:
             stry.append(f"'{id_}'")
@@ -349,10 +376,10 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         # Final filter object
         filter_object = {"filter-lang": "cql2-text", "filter": filter_string, "limit": str(len(ids))}
 
-        search_url = f"{self.catalog_url}/catalog/collections/{self.catalog_collection}/search"
+        search_url = f"{self.catalog_url}/catalog/collections/{catalog_collection}/search"
 
         # Another method is to get all the items and loop with them to match item ids
-        # search_url = f"{self.catalog_url}/catalog/collections/{self.catalog_collection}/items"
+        # search_url = f"{self.catalog_url}/catalog/collections/{catalog_collection}/items"
 
         try:
             response = requests.get(
@@ -371,40 +398,33 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             for item in item_collection.get("features"):
                 self.logger.debug(f"Session {item.get('id')} has {len(item.get('assets'))} assets")
             # end of TODO
-            self.create_streaming_list(item_collection)
+            self.create_streaming_list(features, item_collection)
             return True
-        except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.RequestException,
-            requests.exceptions.ConnectionError,
-            json.JSONDecodeError,
-            RuntimeError,
-        ) as exc:
-            self.logger.error(f"Failed to search catalog: {exc}")
-            self.log_job_execution(JobStatus.failed, 0, message=f"Failed to search catalog: {exc}")
+        except (RequestException, JSONDecodeError, RuntimeError) as exc:
+            self.log_job_execution(JobStatus.failed, 0, f"Failed to search catalog: {exc}")
             return False
 
-    def create_streaming_list(self, catalog_response: dict):
+    def create_streaming_list(self, features: list[Feature], catalog_response: dict):
         """
         Prepares a list of items for download based on the catalog response.
 
         This method compares the features in the provided `catalog_response` with the features
-        already present in `self.item_collection.features`. If all features have been returned
+        already present in `features`. If all features have been returned
         in the catalog response, the streaming list is cleared. Otherwise, it determines which
         items are not yet downloaded and updates `self.stream_list` with those items.
 
         Args:
+            features (list): The list of features to process.
             catalog_response (dict): A dictionary response from a catalog search.
 
         Behavior:
             - If the number of items in `catalog_response["context"]["returned"]` matches the
-            total number of items in `self.item_collection.features`, `self.stream_list`
+            total number of items in `features`, `self.stream_list`
             is set to an empty list, indicating that there are no new items to download.
             - If the `catalog_response["features"]` is empty (i.e., no items were found in the search),
             it assumes no items have been downloaded and sets `self.stream_list` to all features
-            in `self.item_collection.features`.
-            - Otherwise, it computes the difference between the items in `self.item_collection.features`
+            in `features`.
+            - Otherwise, it computes the difference between the items in `features`
             and the items already listed in the catalog response, updating `self.stream_list` to
             contain only those that have not been downloaded yet.
 
@@ -415,30 +435,28 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         # Based on catalog response, pop out features already in catalog and prepare rest for download
         try:
             if not catalog_response["features"]:
-                # No search result found, process everything from self.item_collection
-                self.stream_list = self.item_collection.features
+                # No search result found, process everything from item_collection
+                self.stream_list = features
             else:
                 # Do the difference, call rs-server-download only with features to be downloaded
                 # Extract IDs from the catalog response directly
                 already_downloaded_ids = {feature["id"] for feature in catalog_response["features"]}
                 # Select only features whose IDs have not already been downloaded (returned in /search)
-                not_downloaded_features = [
-                    item for item in self.item_collection.features if item.id not in already_downloaded_ids
-                ]
+                not_downloaded_features = [item for item in features if item.id not in already_downloaded_ids]
                 self.stream_list = not_downloaded_features
         except KeyError as ke:
             self.logger.exception(
-                "The 'features' field is missing in the response from the catalog service. "
-                f"Unable to check the collection {self.catalog_collection}. {ke}",
+                f"The 'features' field is missing in the response from the catalog service. {ke}",
             )
             raise RuntimeError(
-                "The 'features' field is missing in the response from the catalog service. ",
+                "The 'features' field is missing in the response from the catalog service.",
             ) from ke
 
-    def prepare_streaming_tasks(self, feature):
+    def prepare_streaming_tasks(self, catalog_collection: str, feature: Feature):
         """Prepare tasks for the given feature to the Dask cluster.
 
         Args:
+            catalog_collection (str): Name of the catalog collection.
             feature: The feature containing assets to download.
 
         Returns:
@@ -451,7 +469,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
                 return False
             # Add the user_collection as main directory, as soon as the authentication will be
             # implemented in this staging process
-            s3_obj_path = f"{self.catalog_collection}/{feature.id.rstrip('/')}/{asset_name}"
+            s3_obj_path = f"{catalog_collection}/{feature.id.rstrip('/')}/{asset_name}"
             self.assets_info.append((asset_content.href, s3_obj_path))
             # update the s3 path, this will be checked in the rs-server-catalog in the
             # publishing phase
@@ -531,16 +549,20 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         except KeyError as exc:
             self.logger.error("Cannot connect to s3 storage, %s", exc)
 
-    def manage_dask_tasks_results(self, client):
+    def manage_dask_tasks_results(self, client: Client, catalog_collection: str):
         """
         Method used to manage dask tasks.
 
-        As job are completed, progress is dinamically incremented and monitored into DB.
+        As job are completed, progress is dynamically incremented and monitored into DB.
         If a single tasks fails:
             - handle_task_failure() is called
             - processor waits (RSPY_STAGING_TIMEOUT or 600 seconds) untill running tasks are finished
             - the execution of future tasks is canceled.
             - When all streaming tasks are finished, processor removes all files streamed in s3 bucket.
+
+        Args:
+            client (Client): Dask client.
+            catalog_collection (str): Name of the catalog collection.
         """
         self.logger.info("Tasks monitoring started")
         if not client:
@@ -552,8 +574,8 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
                 self.tasks_finished += 1
                 self.log_job_execution(
                     JobStatus.running,
-                    round((self.tasks_finished * 100 / len(self.tasks)), 2),
-                    message="In progress",
+                    round(self.tasks_finished * 100 / len(self.tasks)),
+                    "In progress",
                 )
                 self.logger.debug("%s Task streaming completed", task.key)
             except Exception as task_e:  # pylint: disable=broad-exception-caught
@@ -569,35 +591,31 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
                     time.sleep(1)
                     timeout -= 1
                 # Update status for the job
-                self.log_job_execution(
-                    JobStatus.failed,
-                    None,
-                    message=f"At least one of the tasks failed: {task_e}",
-                )
+                self.log_job_execution(JobStatus.failed, None, f"At least one of the tasks failed: {task_e}")
                 self.delete_files_from_bucket()
                 self.logger.error(f"Tasks monitoring finished with error. At least one of the tasks failed: {task_e}")
                 return
         # Publish all the features once processed
         published_featurs_ids: list[str] = []
         for feature in self.stream_list:
-            if not self.publish_rspy_feature(feature):
+            if not self.publish_rspy_feature(catalog_collection, feature):
                 # cleanup
                 self.log_job_execution(
                     JobStatus.failed,
                     None,
-                    message=f"The item {feature.id} couldn't be " "published in the catalog. Cleaning up",
+                    f"The item {feature.id} couldn't be published in the catalog. Cleaning up",
                 )
                 # delete the files
                 self.delete_files_from_bucket()
                 # delete the published items
-                self.unpublish_rspy_features(published_featurs_ids)
+                self.unpublish_rspy_features(catalog_collection, published_featurs_ids)
                 return
             published_featurs_ids.append(feature.id)
         # Update status once all features are processed
-        self.log_job_execution(JobStatus.successful, 100, message="Finished")
+        self.log_job_execution(JobStatus.successful, 100, "Finished")
         self.logger.info("Tasks monitoring finished")
 
-    def dask_cluster_connect(self):
+    def dask_cluster_connect(self) -> Client:
         """Connects a dask cluster scheduler
         Establishes a connection to a Dask cluster, either in a local environment or via a Dask Gateway in
         a Kubernetes cluster. This method checks if the cluster is already created (for local mode) or connects
@@ -612,9 +630,6 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             (using environment variables `DASK_GATEWAY__ADDRESS` and `DASK_GATEWAY__AUTH__TYPE`) to
             retrieve a list of existing clusters.
         - If no clusters are available, it attempts to create a new cluster scheduler.
-
-        Args:
-            None
 
         Raises:
             RuntimeError: Raised if the cluster name is None, required environment variables are missing,
@@ -651,7 +666,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             - If an error occurs, the method logs the error and attempts to gracefully handle failure.
 
         Returns:
-            None
+            Dask client
         """
 
         # If self.cluster is already initialized, it means the application is running in local mode, and
@@ -742,6 +757,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         Args:
             token (str): Authentication token used for accessing and processing the asset download
             from the external station (wrapped in `TokenAuth`).
+            trusted_domains (list): List of allowed hosts for redirection in case of change of protocol (HTTP <> HTTPS).
             client (Client): The dask cluster client created in the dask_cluster_connect function
 
         Raises:
@@ -772,35 +788,36 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             self.logger.exception(f"Submitting task to dask cluster failed. Reason: {e}")
             raise RuntimeError(f"Submitting task to dask cluster failed. Reason: {e}") from e
 
-    async def process_rspy_features(self):
+    async def process_rspy_features(self, catalog_collection: str) -> tuple[str, dict]:
         """
         Method used to trigger dask distributed streaming process.
         It creates dask client object, gets the external data sources access token
         Prepares the tasks for execution
         Manage eventual runtime exceptions
+
+        Args:
+            catalog_collection (str): Name of the catalog collection.
+
+        Returns:
+            tuple: tuple of MIME type and process response (dictionary containing the job ID and a
+                status message).
+                Example: ("application/json", {"running": <job_id>})
         """
         self.logger.debug("Starting main loop")
 
         # Process each feature by initiating the streaming download of its assets to the final bucket.
         for feature in self.stream_list:
-            if not self.prepare_streaming_tasks(feature):
-                self.log_job_execution(JobStatus.failed, 0, message="Unable to create tasks for the Dask cluster")
-                return
+            if not self.prepare_streaming_tasks(catalog_collection, feature):
+                return self.log_job_execution(JobStatus.failed, 0, "Unable to create tasks for the Dask cluster")
         if not self.assets_info:
-            self.log_job_execution(JobStatus.successful, 100, message="Finished without processing any tasks")
             self.logger.info("There are no assets to stage. Exiting....")
-            return
+            return self.log_job_execution(JobStatus.successful, 100, "Finished without processing any tasks")
 
         # Determine the domain(s)
         domains = list({urlparse(asset[0]).hostname for asset in self.assets_info})
         self.logger.info("Staging from domain(s) {domains}")
         if len(domains) > 1:
-            self.log_job_execution(
-                JobStatus.failed,
-                0,
-                message="Staging from multiple domains is not supported yet",
-            )
-            return
+            return self.log_job_execution(JobStatus.failed, 0, "Staging from multiple domains is not supported yet")
         domain = domains[0]
 
         # retrieve the token
@@ -811,38 +828,37 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             self.logger.error(
                 f"Failed to retrieve the token needed to connect to the external station: {http_exception}",
             )
-            self.log_job_execution(
+            return self.log_job_execution(
                 JobStatus.failed,
                 0,
-                message=f"Failed to retrieve the token needed to connect to the external station {domain}",
+                f"Failed to retrieve the token needed to connect to the external station {domain}",
             )
-            return
 
         # connect to the dask cluster
         try:
-            dask_client = self.dask_cluster_connect()
+            dask_client: Client = self.dask_cluster_connect()
             self.submit_tasks_to_dask_cluster(token, external_auth_config.trusted_domains, dask_client)
         except RuntimeError as re:
-            self.log_job_execution(JobStatus.failed, 0, message=f"{re}")
             self.logger.error("Failed to start the staging process")
-            return
+            return self.log_job_execution(JobStatus.failed, 0, f"{re}")
 
         # Set the status to running for the job
-        self.log_job_execution(JobStatus.running, 0, message="Sending tasks to the dask cluster")
+        self.log_job_execution(JobStatus.running, 0, "Sending tasks to the dask cluster")
 
         # starting another thread for managing the dask callbacks
         self.logger.debug("Starting tasks monitoring thread")
         try:
-            await asyncio.to_thread(self.manage_dask_tasks_results, dask_client)
+            await asyncio.to_thread(self.manage_dask_tasks_results, dask_client, catalog_collection)
         except Exception as e:  # pylint: disable=broad-exception-caught
-            self.logger.debug(f"Error from tasks monitoring thread: {e}")
-            self.log_job_execution(JobStatus.failed, 0, message=f"Error from tasks monitoring thread: {e}")
+            self.log_job_execution(JobStatus.failed, 0, f"Error from tasks monitoring thread: {e}")
 
         # cleanup by disconnecting the dask client
         self.assets_info = []
         dask_client.close()
 
-    def publish_rspy_feature(self, feature: Feature):
+        return self._get_execute_result()
+
+    def publish_rspy_feature(self, catalog_collection: str, feature: Feature):
         """
         Publishes a given feature to the RSPY catalog.
 
@@ -851,6 +867,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         and published to the `/catalog/collections/{collectionId}/items` endpoint.
 
         Args:
+            catalog_collection (str): Name of the catalog collection.
             feature (dict): The feature to be published, represented as a dictionary. It should
             include all necessary attributes required by the catalog.
 
@@ -859,11 +876,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             in case of an error.
 
         Raises:
-            requests.exceptions.HTTPError: Raised if the server returns an HTTP error response.
-            requests.exceptions.Timeout: Raised if the request times out.
-            requests.exceptions.RequestException: Raised for general request issues.
-            requests.exceptions.ConnectionError: Raised if there's a connection error.
-            json.JSONDecodeError: Raised if the response cannot be decoded as JSON.
+            None directly (all exceptions are caught and logged).
 
         Logging:
             - Logs an error message with details if the request fails.
@@ -872,7 +885,7 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         """
         # Publish feature to catalog
         # how to get user? // Do we need user? should /catalog/collection/collectionId/items works with apik?
-        publish_url = f"{self.catalog_url}/catalog/collections/{self.catalog_collection}/items"
+        publish_url = f"{self.catalog_url}/catalog/collections/{catalog_collection}/items"
         # Iterate over assets, and remove alternate field, if they already have one defined.
         for asset in feature.assets.values():
             if hasattr(asset, "alternate"):
@@ -886,17 +899,11 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
             )
             response.raise_for_status()  # Raise an error for HTTP error responses
             return True
-        except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.RequestException,
-            requests.exceptions.ConnectionError,
-            json.JSONDecodeError,
-        ) as exc:
+        except (RequestException, JSONDecodeError) as exc:
             self.logger.error("Error while publishing items to rspy catalog %s", exc)
             return False
 
-    def unpublish_rspy_features(self, feature_ids: list[str]):
+    def unpublish_rspy_features(self, catalog_collection: str, feature_ids: list[str]):
         """Deletes specified features from the RSPy catalog by sending DELETE requests to the
         catalog API endpoint for each feature ID.
 
@@ -905,14 +912,11 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         fails due to HTTP errors, timeouts, or connection issues, it logs the error with appropriate details.
 
         Args:
+            catalog_collection (str): Name of the catalog collection.
             feature_ids (list): A list of feature IDs to be deleted from the RSPy catalog.
 
         Raises:
-            requests.exceptions.HTTPError: If the server responds with an HTTP error code (4xx or 5xx).
-            requests.exceptions.Timeout: If the DELETE request times out.
-            requests.exceptions.RequestException: For general request-related errors.
-            requests.exceptions.ConnectionError: If there is a network-related error.
-            json.JSONDecodeError: If an invalid response body is encountered when attempting to decode.
+            None directly (all exceptions are caught and logged).
 
         Behavior:
         1. **Request Construction**:
@@ -935,22 +939,14 @@ class Staging(BaseProcessor):  # (metaclass=MethodWrapperMeta): - meta for stopp
         """
         try:
             for feature_id in feature_ids:
-                catalog_delete_item = (
-                    f"{self.catalog_url}/catalog/collections/{self.catalog_collection}/items/{feature_id}"
-                )
+                catalog_delete_item = f"{self.catalog_url}/catalog/collections/{catalog_collection}/items/{feature_id}"
                 response = requests.delete(
                     catalog_delete_item,
                     headers={"cookie": self.headers.get("cookie", None)},
                     timeout=3,
                 )
                 response.raise_for_status()  # Raise an error for HTTP error responses
-        except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.RequestException,
-            requests.exceptions.ConnectionError,
-            json.JSONDecodeError,
-        ) as exc:
+        except (RequestException, JSONDecodeError) as exc:
             self.logger.error("Error while deleting the item from rspy catalog %s", exc)
 
     def __repr__(self):

--- a/services/staging/tests/conftest.py
+++ b/services/staging/tests/conftest.py
@@ -131,14 +131,33 @@ def dbj_():
     ]
 
 
+def feature(f_id: str) -> dict:
+    """Create a new empty Feature"""
+    return {
+        "type": "Feature",
+        "properties": {},
+        "id": f_id,
+        "stac_version": "1.0.0",
+        "assets": {"asset1": {"href": "https://fake-data"}},
+        "stac_extensions": [],
+    }
+
+
+@pytest.fixture(name="staging_inputs")
+def staging_inputs():
+    """Fixture to mock the staging execution inputs"""
+    return {
+        "collection": {"id": "test_collection"},
+        "items": {"type": "FeatureCollection", "features": [feature("1"), feature("2")]},
+    }
+
+
 @pytest.fixture(name="staging_instance")
 def staging(mocker):
     """Fixture to mock the Staging object"""
     # Mock dependencies for Staging
     mock_credentials = mocker.Mock()
     mock_credentials.headers = {"cookie": "fake-cookie", "host": "fake-host"}
-    mock_input_collection = mocker.Mock()
-    mock_collection = "test_collection"
     mock_item = "test_item"
     mock_db = mocker.Mock()  # Mock for PostgreSQL Manager
     mock_cluster = mocker.Mock()  # Mock for LocalCluster
@@ -153,8 +172,6 @@ def staging(mocker):
     # Instantiate the Staging class with the mocked dependencies
     staging_instance = Staging(
         credentials=mock_credentials,
-        input_collection=mock_input_collection,
-        collection=mock_collection,
         item=mock_item,
         db_process_manager=mock_db,
         cluster=mock_cluster,

--- a/services/staging/tests/test_rspy_processor.py
+++ b/services/staging/tests/test_rspy_processor.py
@@ -25,7 +25,8 @@ import requests
 from dask_gateway import Gateway
 from fastapi import HTTPException
 from pygeoapi.util import JobStatus
-from rs_server_staging.processors import TokenAuth, streaming_task
+from rs_server_staging.processors import Staging, TokenAuth, streaming_task
+from rs_server_staging.rspy_models import FeatureCollectionModel
 
 # pylint: disable=undefined-variable
 # pylint: disable=no-member
@@ -128,85 +129,92 @@ class TestStaging:
     """Test class for Staging processor"""
 
     @pytest.mark.asyncio
-    async def test_execute_with_running_loop(self, mocker, staging_instance, asyncio_loop):
+    async def test_execute_with_running_loop(
+        self,
+        mocker,
+        staging_instance: Staging,
+        staging_inputs: dict,
+        asyncio_loop,
+    ):
         """Test execute method while a asyncio loop is running"""
-        mock_log_job = mocker.patch.object(staging_instance, "log_job_execution")
+        spy_log_job = mocker.spy(staging_instance, "log_job_execution")
         mock_check_catalog = mocker.patch.object(staging_instance, "check_catalog", return_value=True)
         mock_process_rspy = mocker.patch.object(staging_instance, "process_rspy_features", return_value=True)
-        # Mocking the item_collection and its features
-        staging_instance.item_collection = mocker.Mock()
-        staging_instance.item_collection.features = [mocker.Mock(id="1"), mocker.Mock(id="2")]
         # Simulate an already running event loop
         mocker.patch.object(asyncio, "get_event_loop", return_value=asyncio_loop)
         mocker.patch.object(asyncio_loop, "is_running", return_value=True)
 
         # Call the async execute method
-        result = await staging_instance.execute()
+        result = await staging_instance.execute(staging_inputs)
 
         # Assertions
-        assert mock_log_job.call_count == 1
-        mock_log_job.assert_has_calls(
-            [call(JobStatus.running, 0, message="Successfully searched catalog")],
+        assert spy_log_job.call_count == 1
+        spy_log_job.assert_has_calls(
+            [call(JobStatus.running, 0, "Successfully searched catalog")],
         )
         mock_check_catalog.assert_called_once()
         mock_process_rspy.assert_called_once()  # Ensures processing is scheduled
-        assert result == {"running": staging_instance.job_id}
+        assert result == ("application/json", {"running": staging_instance.job_id})
 
     @pytest.mark.asyncio
-    async def test_execute_fails_in_checking_catalog(self, mocker, staging_instance, asyncio_loop):
+    async def test_execute_fails_in_checking_catalog(
+        self,
+        mocker,
+        staging_instance: Staging,
+        staging_inputs: dict,
+        asyncio_loop,
+    ):
         """Test execute method while a asyncio loop is running"""
-        mock_log_job = mocker.patch.object(staging_instance, "log_job_execution")
+        spy_log_job = mocker.spy(staging_instance, "log_job_execution")
         mock_check_catalog = mocker.patch.object(staging_instance, "check_catalog", return_value=False)
-        # Mocking the item_collection and its features
-        staging_instance.item_collection = mocker.Mock()
-        staging_instance.item_collection.features = [mocker.Mock(id="1"), mocker.Mock(id="2")]
         # Simulate an already running event loop
         mocker.patch.object(asyncio, "get_event_loop", return_value=asyncio_loop)
         mocker.patch.object(asyncio_loop, "is_running", return_value=True)
 
         # Call the async execute method
-        result = await staging_instance.execute()
+        result = await staging_instance.execute(staging_inputs)
 
         # Assertions
-        assert mock_log_job.call_count == 1
-        mock_log_job.assert_has_calls(
+        assert spy_log_job.call_count == 1
+        spy_log_job.assert_has_calls(
             [
                 call(
                     JobStatus.failed,
                     0,
-                    message="Failed to start the staging process. "
-                    f"Checking the collection '{staging_instance.catalog_collection}' failed !",
+                    "Failed to start the staging process. Checking the collection 'test_collection' failed !",
                 ),
             ],
         )
         mock_check_catalog.assert_called_once()
 
-        assert result == {"failed": staging_instance.job_id}
+        assert result == ("application/json", {"failed": staging_instance.job_id})
 
     @pytest.mark.asyncio
-    async def test_execute_with_running_loop_without_item_collection(self, mocker, staging_instance, asyncio_loop):
+    async def test_execute_with_running_loop_without_item_collection(
+        self,
+        mocker,
+        staging_instance: Staging,
+        asyncio_loop,
+    ):
         """Test execute method while a asyncio loop is running"""
-        mock_log_job = mocker.patch.object(staging_instance, "log_job_execution")
+        spy_log_job = mocker.spy(staging_instance, "log_job_execution")
 
         # Simulate an already running event loop
         mocker.patch.object(asyncio, "get_event_loop", return_value=asyncio_loop)
         mocker.patch.object(asyncio_loop, "is_running", return_value=True)
 
-        # set item_collection to None
-        staging_instance.item_collection = None
-
         # Call the async execute method
-        result = await staging_instance.execute()
+        result = await staging_instance.execute(data={"collection": {"id": "test_collection"}})
 
         # Assertions
-        mock_log_job.assert_called_once_with(
+        spy_log_job.assert_called_once_with(
             JobStatus.successful,
             0,
-            message="No valid items were provided in the input for staging",
+            "No valid items were provided in the input for staging",
         )
-        assert result == {"successful": staging_instance.job_id}
+        assert result == ("application/json", {"successful": staging_instance.job_id})
 
-    def test_create_job_execution(self, staging_instance, mocker):
+    def test_create_job_execution(self, staging_instance: Staging, mocker):
         """Test the create_job_execution method of the Staging class.
 
         This test verifies that the create_job_execution method correctly inserts a new job execution
@@ -241,7 +249,7 @@ class TestStaging:
             },
         )
 
-    def test_log_job_execution(self, staging_instance, mocker):
+    def test_log_job_execution(self, staging_instance: Staging, mocker):
         """Test the log_job_execution method of the Staging class.
 
         This test verifies that the log_job_execution method correctly updates the job's status,
@@ -288,9 +296,9 @@ class TestStaging:
 
         # Call log_job_execution to test status update with custom attrs
         staging_instance.log_job_execution(
-            status=JobStatus.running,
-            progress=50.0,
-            message="Job is halfway done.",
+            JobStatus.running,
+            50.0,
+            "Job is halfway done.",
         )
 
         # Assert that the update method was called with the custom parameters
@@ -308,8 +316,14 @@ class TestStaging:
 class TestStagingCatalog:
     """Group of all tests used for method that search the catalog before processing."""
 
+    def _call_check_catalog(self, staging_instance: Staging, staging_inputs: dict):
+        return staging_instance.check_catalog(
+            staging_inputs["collection"]["id"],
+            FeatureCollectionModel.parse_obj(staging_inputs["items"]).features,
+        )
+
     @pytest.mark.asyncio
-    async def test_check_catalog_success(self, mocker, staging_instance):
+    async def test_check_catalog_success(self, mocker, staging_instance: Staging, staging_inputs: dict):
         """Test the check_catalog method for successful execution.
 
         This test verifies that the check_catalog method correctly formats the request
@@ -319,10 +333,6 @@ class TestStagingCatalog:
             mocker: The mocker fixture to patch methods and objects during tests.
             staging_instance (Staging): An instance of the Staging class, pre-initialized for testing.
         """
-        # Mocking the item_collection and its features
-        staging_instance.item_collection = mocker.Mock()
-        staging_instance.item_collection.features = [mocker.Mock(id="1"), mocker.Mock(id="2")]
-
         # Setting up the catalog_url and headers
         staging_instance.catalog_url = "https://test_rspy_catalog_url.com"
 
@@ -337,7 +347,7 @@ class TestStagingCatalog:
         mocker.patch("requests.get", return_value=mock_response)
 
         # Call the method under test
-        result = await staging_instance.check_catalog()
+        result = await self._call_check_catalog(staging_instance, staging_inputs)
 
         # Assert that the result is True (successful catalog check)
         assert result is True
@@ -357,12 +367,8 @@ class TestStagingCatalog:
         mock_log_job_execution.called_once()
 
     @pytest.mark.asyncio
-    async def test_check_catalog_get_wrong_response(self, mocker, staging_instance):
+    async def test_check_catalog_get_wrong_response(self, mocker, staging_instance: Staging, staging_inputs: dict):
         """docstring to be added"""
-        # Mocking the item_collection and its features
-        staging_instance.item_collection = mocker.Mock()
-        staging_instance.item_collection.features = [mocker.Mock(id="1"), mocker.Mock(id="2")]
-
         # Setting up the catalog_url and headers
         staging_instance.catalog_url = "https://test_rspy_catalog_url.com"
 
@@ -373,18 +379,14 @@ class TestStagingCatalog:
         mocker.patch("requests.get", return_value=mock_response)
 
         # Call the method under test
-        result = await staging_instance.check_catalog()
+        result = await self._call_check_catalog(staging_instance, staging_inputs)
 
         # Assert that the result is True (successful catalog check)
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_check_catalog_failure(self, mocker, staging_instance):
+    async def test_check_catalog_failure(self, mocker, staging_instance: Staging, staging_inputs: dict):
         """docstring to be added"""
-        # Mocking the item_collection and its features
-        staging_instance.item_collection = mocker.Mock()
-        staging_instance.item_collection.features = [mocker.Mock(id=1), mocker.Mock(id=2)]
-
         # Setting up the catalog_url and headers
         staging_instance.catalog_url = "https://test_rspy_catalog_url.com"
 
@@ -405,7 +407,7 @@ class TestStagingCatalog:
             mock_create_streaming_list = mocker.patch.object(staging_instance, "create_streaming_list")
 
             # Call the method under test
-            result = await staging_instance.check_catalog()
+            result = await self._call_check_catalog(staging_instance, staging_inputs)
 
             # Assert that the result is False (failed catalog check)
             assert result is False
@@ -415,7 +417,7 @@ class TestStagingCatalog:
             mock_log_job_execution.assert_called_once_with(
                 JobStatus.failed,
                 0,
-                message=f"Failed to search catalog: {get_err_msg}",
+                f"Failed to search catalog: {get_err_msg}",
             )
 
         # Mock the requests.get method
@@ -431,77 +433,77 @@ class TestStagingCatalog:
             side_effect=RuntimeError(err_msg),
         )
         # Call the method under test
-        await staging_instance.check_catalog()
+        await self._call_check_catalog(staging_instance, staging_inputs)
         mock_log_job_execution.assert_called_once_with(
             JobStatus.failed,
             0,
-            message=f"Failed to search catalog: {err_msg}",
+            f"Failed to search catalog: {err_msg}",
         )
 
 
 class TestPrepareStreaming:
     """Class that groups tests for methods that prepare inputs for streaming process."""
 
-    def test_create_streaming_list_all_downloaded(self, mocker, staging_instance):
+    def test_create_streaming_list_all_downloaded(self, mocker, staging_instance: Staging):
         """Test create_streaming_list when all features are already downloaded."""
-        # Set up the staging instance
-        staging_instance.item_collection.features = [mocker.Mock(id=1), mocker.Mock(id=2)]
+        features = [mocker.Mock(id=1), mocker.Mock(id=2)]
 
         # Create a mock catalog response indicating all features have been downloaded
         catalog_response = {"context": {"returned": 2}, "features": [{"id": 1}, {"id": 2}]}
 
         # Call the method under test
-        staging_instance.create_streaming_list(catalog_response)
+        staging_instance.create_streaming_list(features, catalog_response)
 
         # Assert that stream_list is empty
         assert staging_instance.stream_list == []
 
-    def test_create_streaming_list_no_download(self, mocker, staging_instance):
+    def test_create_streaming_list_no_download(self, mocker, staging_instance: Staging):
         """Test create_streaming_list when no features are found in the catalog."""
-        staging_instance.item_collection.features = [mocker.Mock(id=1), mocker.Mock(id=2)]
+        features = [mocker.Mock(id=1), mocker.Mock(id=2)]
 
         # Create a mock catalog response with no features found
         catalog_response = {"context": {"returned": 0}, "features": []}
 
-        staging_instance.create_streaming_list(catalog_response)
+        staging_instance.create_streaming_list(features, catalog_response)
 
         # Assert that stream_list contains all features
-        assert staging_instance.stream_list == staging_instance.item_collection.features
+        assert staging_instance.stream_list == features
 
-    def test_create_streaming_list_partial_download(self, mocker, staging_instance):
+    def test_create_streaming_list_partial_download(self, mocker, staging_instance: Staging):
         """Test create_streaming_list when some features are not yet downloaded."""
         feature_1 = mocker.Mock(id=1)
         feature_2 = mocker.Mock(id=2)
         feature_3 = mocker.Mock(id=3)
-        staging_instance.item_collection.features = [feature_1, feature_2, feature_3]
+        features = [feature_1, feature_2, feature_3]
 
         # Create a mock catalog response indicating only some features have been downloaded
         # Only feature 1 has been already staged
         catalog_response = {"context": {"returned": 1}, "features": [{"id": 1}]}
 
-        staging_instance.create_streaming_list(catalog_response)
+        staging_instance.create_streaming_list(features, catalog_response)
 
         # Assert that stream_list contains features 2 and 3 (not downloaded)
         assert staging_instance.stream_list == [feature_2, feature_3]
 
-    def test_create_streaming_list_wrong_catalog_input(self, mocker, staging_instance):
+    def test_create_streaming_list_wrong_catalog_input(self, mocker, staging_instance: Staging):
         """Test create_streaming_list when a wrong response is received from the catalog."""
         feature_1 = mocker.Mock(id=1)
         feature_2 = mocker.Mock(id=2)
         feature_3 = mocker.Mock(id=3)
-        staging_instance.item_collection.features = [feature_1, feature_2, feature_3]
+        features = [feature_1, feature_2, feature_3]
 
         # Create a mock catalog response which is malformed
         catalog_response = {"context": {"returned": 1}, "wrong_key": [{"id": 1}]}
 
         with pytest.raises(
             RuntimeError,
-            match="The 'features' field is missing in the response from the catalog service. ",
+            match="The 'features' field is missing in the response from the catalog service.",
         ):
-            staging_instance.create_streaming_list(catalog_response)
+            staging_instance.create_streaming_list(features, catalog_response)
 
-    def test_prepare_streaming_tasks_all_valid(self, mocker, staging_instance):
+    def test_prepare_streaming_tasks_all_valid(self, mocker, staging_instance: Staging):
         """Test prepare_streaming_tasks when all assets are valid."""
+        catalog_collection = "test_collection"
         feature = mocker.Mock()
         feature.id = "feature_id"
         feature.assets = {
@@ -509,36 +511,29 @@ class TestPrepareStreaming:
             "asset2": mocker.Mock(href="https://example.com/asset2"),
         }
 
-        result = staging_instance.prepare_streaming_tasks(feature)
+        result = staging_instance.prepare_streaming_tasks(catalog_collection, feature)
 
         # Assert that the method returns True
         assert result is True
         # Assert that assets_info has been populated correctly
         assert staging_instance.assets_info == [
-            ("https://example.com/asset1", f"{staging_instance.catalog_collection}/{feature.id}/asset1"),
-            ("https://example.com/asset2", f"{staging_instance.catalog_collection}/{feature.id}/asset2"),
+            ("https://example.com/asset1", f"{catalog_collection}/{feature.id}/asset1"),
+            ("https://example.com/asset2", f"{catalog_collection}/{feature.id}/asset2"),
         ]
         # Assert that asset hrefs are updated correctly
-        assert (
-            feature.assets["asset1"].href
-            == f"s3://rtmpop/{staging_instance.catalog_collection}/{feature.id}/\
-asset1"
-        )
-        assert (
-            feature.assets["asset2"].href
-            == f"s3://rtmpop/{staging_instance.catalog_collection}/{feature.id}/\
-asset2"
-        )
+        assert feature.assets["asset1"].href == f"s3://rtmpop/{catalog_collection}/{feature.id}/asset1"
+        assert feature.assets["asset2"].href == f"s3://rtmpop/{catalog_collection}/{feature.id}/asset2"
 
-    def test_prepare_streaming_tasks_one_invalid(self, mocker, staging_instance):
+    def test_prepare_streaming_tasks_one_invalid(self, mocker, staging_instance: Staging):
         """Test prepare_streaming_tasks when all assets are valid."""
+        catalog_collection = "test_collection"
         feature = mocker.Mock()
         feature.id = "feature_id"
         feature.assets = {
             "asset1": mocker.Mock(href="", title="asset1_title"),
             "asset2": mocker.Mock(href="https://example.com/asset2", title="asset2_title"),
         }
-        result = staging_instance.prepare_streaming_tasks(feature)
+        result = staging_instance.prepare_streaming_tasks(catalog_collection, feature)
 
         # Assert that the method returns False
         assert result is False
@@ -547,7 +542,7 @@ asset2"
 class TestStagingTaskFailure:  # pylint: disable=too-few-public-methods
     """Class to group tests that handle dask task failure"""
 
-    def test_handle_task_failure_all_tasks_canceled(self, mocker, staging_instance):
+    def test_handle_task_failure_all_tasks_canceled(self, mocker, staging_instance: Staging):
         """Test handle_task_failure when all tasks are successfully canceled."""
         # Create mock tasks
         task_1 = mocker.Mock()
@@ -570,7 +565,7 @@ class TestStagingTaskFailure:  # pylint: disable=too-few-public-methods
         task_1.cancel.assert_called_once()
         task_2.cancel.assert_called_once()
 
-    def test_handle_task_failure_with_canceled_error(self, mocker, staging_instance):
+    def test_handle_task_failure_with_canceled_error(self, mocker, staging_instance: Staging):
         """Test handle_task_failure when one task raises CanceledError"""
         # Mock task objects
         mock_task1 = mocker.Mock()
@@ -625,7 +620,7 @@ class TestStagingTaskFailure:  # pylint: disable=too-few-public-methods
 class TestStagingDeleteFromBucket:
     """Class used to group tests that handle file bucket removal if failure"""
 
-    def test_delete_files_from_bucket_succes(self, mocker, staging_instance):
+    def test_delete_files_from_bucket_succes(self, mocker, staging_instance: Staging):
         """Test all files were removed from given bucket"""
         mocker.patch.dict(
             os.environ,
@@ -646,7 +641,7 @@ class TestStagingDeleteFromBucket:
         # Assert that S3StorageHandler was instantiated with the correct environment variables
         mock_s3_handler.delete_file_from_s3.assert_called_once_with("fake_bucket", "fake_s3_path")
 
-    def test_delete_files_from_bucket_empty(self, mocker, staging_instance):
+    def test_delete_files_from_bucket_empty(self, mocker, staging_instance: Staging):
         """Test delete files with no assets, nothing should happen."""
         staging_instance.assets_info = []
         # Mock S3StorageHandler to ensure it's not used
@@ -657,7 +652,7 @@ class TestStagingDeleteFromBucket:
         # Assert that delete_file_from_s3 was never called since there are no assets
         mock_s3_handler.delete_file_from_s3.assert_not_called()
 
-    def test_delete_files_from_bucket_failed_to_create_s3_handler(self, mocker, staging_instance):
+    def test_delete_files_from_bucket_failed_to_create_s3_handler(self, mocker, staging_instance: Staging):
         """Test a failure in creating s3 storage handler."""
         # Mock the environment variables but leave one out to trigger KeyError
         mocker.patch.dict(
@@ -678,7 +673,7 @@ class TestStagingDeleteFromBucket:
         # Assert that the error was logged
         mock_logger.error.assert_called_once_with("Cannot connect to s3 storage, %s", mocker.ANY)
 
-    def test_delete_files_from_bucket_fail_while_in_progress(self, mocker, staging_instance):
+    def test_delete_files_from_bucket_fail_while_in_progress(self, mocker, staging_instance: Staging):
         """Test a runtime error while using s3_handler.delete_file_from_s3, should produce a logger error,
         nothing else?
         """
@@ -708,7 +703,7 @@ class TestStagingDeleteFromBucket:
 class TestStagingMainExecution:
     """Class to test Item processing"""
 
-    def test_dask_cluster_connect(self, mocker, staging_instance, cluster_options):
+    def test_dask_cluster_connect(self, mocker, staging_instance: Staging, cluster_options):
         """Test to mock the connection to a dask cluster"""
         # Mock environment variables to simulate gateway mode
         mocker.patch.dict(
@@ -760,7 +755,7 @@ class TestStagingMainExecution:
             f"Dask Client: {client} | Cluster dashboard: {mock_connect.return_value.dashboard_link}",
         )
 
-    def test_dask_cluster_connect_failure_no_cluster_name(self, mocker, staging_instance, cluster_options):
+    def test_dask_cluster_connect_failure_no_cluster_name(self, mocker, staging_instance: Staging, cluster_options):
         """Test the bahavior in case no cluster name is found"""
         non_existent_cluster = "another-cluster-name"
         # Mock environment variables to simulate gateway mode
@@ -799,7 +794,7 @@ class TestStagingMainExecution:
             "Failed to find the specified dask cluster: " f"No dask cluster named '{non_existent_cluster}' was found.",
         )
 
-    def test_dask_cluster_connect_failure_no_envs(self, mocker, staging_instance):
+    def test_dask_cluster_connect_failure_no_envs(self, mocker, staging_instance: Staging):
         """Test to mock the connection to a dask cluster"""
         # Not all the needed env vars are mocked
         mocker.patch.dict(
@@ -812,7 +807,7 @@ class TestStagingMainExecution:
         with pytest.raises(RuntimeError):
             staging_instance.dask_cluster_connect()
 
-    def test_manage_dask_tasks_results_succesfull(self, mocker, staging_instance):
+    def test_manage_dask_tasks_results_succesfull(self, mocker, staging_instance: Staging):
         """Test to mock managing of successul tasks"""
         # Mock tasks that will succeed
         task1 = mocker.Mock()
@@ -831,16 +826,16 @@ class TestStagingMainExecution:
         mock_log_job = mocker.patch.object(staging_instance, "log_job_execution")
         mock_publish_feature = mocker.patch.object(staging_instance, "publish_rspy_feature")
 
-        staging_instance.manage_dask_tasks_results(client)
+        staging_instance.manage_dask_tasks_results(client, "test_collection")
 
-        # mock_log_job.assert_any_call(JobStatus.running, None, message='In progress')
+        # mock_log_job.assert_any_call(JobStatus.running, None, 'In progress')
         # Check that status was updated 3 times during execution, 1 time for each task, and 1 time with FINISH
-        mock_log_job.assert_any_call(JobStatus.successful, 100, message="Finished")
+        mock_log_job.assert_any_call(JobStatus.successful, 100, "Finished")
         assert mock_log_job.call_count == 3
         # Check that feature publish method was called.
         mock_publish_feature.assert_called()
 
-    def test_manage_dask_tasks_results_failure(self, mocker, staging_instance):
+    def test_manage_dask_tasks_results_failure(self, mocker, staging_instance: Staging):
         """Test handling callbacks when error on one task"""
         task1 = mocker.Mock()
         task1.result = mocker.Mock(return_value=None, side_effect=Exception)  # Simulate a exception in task
@@ -857,16 +852,16 @@ class TestStagingMainExecution:
         # Set timeout to 0, in order to skip that while loop
         mocker.patch.dict("os.environ", {"RSPY_STAGING_TIMEOUT": "0"})
 
-        staging_instance.manage_dask_tasks_results(client)
+        staging_instance.manage_dask_tasks_results(client, "test_collection")
 
         mock_task_failure.assert_called()  # handle_task_failure called once
         mock_delete_file_from_bucket.assert_called()  # Bucket removal called once
         # logger set status to failed
-        mock_log_job.assert_called_once_with(JobStatus.failed, None, message="At least one of the tasks failed: ")
+        mock_log_job.assert_called_once_with(JobStatus.failed, None, "At least one of the tasks failed: ")
         # Features are not published here.
         mock_publish_feature.assert_not_called()
 
-    def test_manage_dask_tasks_failed_to_publish(self, mocker, staging_instance):
+    def test_manage_dask_tasks_failed_to_publish(self, mocker, staging_instance: Staging):
         """Test to mock managing of successul tasks"""
         # Mock tasks that will succeed
         task1 = mocker.Mock()
@@ -887,23 +882,23 @@ class TestStagingMainExecution:
         mocker.patch.object(staging_instance, "publish_rspy_feature", return_value=False)
         mock_delete_file_from_bucket = mocker.patch.object(staging_instance, "delete_files_from_bucket")
 
-        staging_instance.manage_dask_tasks_results(client)
+        staging_instance.manage_dask_tasks_results(client, "test_collection")
 
         mock_log_job.assert_any_call(
             JobStatus.failed,
             None,
-            message=f"The item {task1.id} couldn't be " "published in the catalog. Cleaning up",
+            f"The item {task1.id} couldn't be published in the catalog. Cleaning up",
         )
         mock_delete_file_from_bucket.assert_called()
 
-    def test_manage_dask_tasks_no_dask_client(self, mocker, staging_instance):
+    def test_manage_dask_tasks_no_dask_client(self, mocker, staging_instance: Staging):
         """Test the manage_dask_tasks when no valid dask client is received"""
         mock_logger = mocker.patch.object(staging_instance, "logger")
-        staging_instance.manage_dask_tasks_results(None)
+        staging_instance.manage_dask_tasks_results(None, "test_collection")
         mock_logger.error.assert_called_once_with("The dask cluster client object is not created. Exiting")
 
     @pytest.mark.asyncio
-    async def test_process_rspy_features_empty_assets(self, mocker, staging_instance):
+    async def test_process_rspy_features_empty_assets(self, mocker, staging_instance: Staging):
         """Test that process_rspy_features handles task preparation failure."""
 
         # Mock dependencies
@@ -915,13 +910,13 @@ class TestStagingMainExecution:
         staging_instance.stream_list = [mock_feature]
 
         # Call the method
-        await staging_instance.process_rspy_features()
+        await staging_instance.process_rspy_features("test_collection")
 
         # Ensure the task preparation failed, and method returned early
-        mock_log_job.assert_called_with(JobStatus.failed, 0, message="Unable to create tasks for the Dask cluster")
+        mock_log_job.assert_called_with(JobStatus.failed, 0, "Unable to create tasks for the Dask cluster")
 
     @pytest.mark.asyncio
-    async def test_process_rspy_features_empty_stream(self, mocker, staging_instance):
+    async def test_process_rspy_features_empty_stream(self, mocker, staging_instance: Staging):
         """Test that process_rspy_features logs the initial setup and starts the main loop."""
 
         # Mock dependencies
@@ -932,13 +927,13 @@ class TestStagingMainExecution:
         staging_instance.stream_list = []
 
         # Call the method
-        await staging_instance.process_rspy_features()
+        await staging_instance.process_rspy_features("test_collection")
 
         # Assert initial logging and job execution calls
-        mock_log_job.assert_called_with(JobStatus.successful, 100, message="Finished without processing any tasks")
+        mock_log_job.assert_called_with(JobStatus.successful, 100, "Finished without processing any tasks")
 
     @pytest.mark.asyncio
-    async def test_process_rspy_features_token_failure(self, mocker, staging_instance):
+    async def test_process_rspy_features_token_failure(self, mocker, staging_instance: Staging):
         """Test case where retrieving the token raises an exception."""
         # Mock the logger
         mock_logger = mocker.patch.object(staging_instance, "logger")
@@ -960,7 +955,7 @@ class TestStagingMainExecution:
         )
 
         # Call the async function
-        await staging_instance.process_rspy_features()
+        await staging_instance.process_rspy_features("test_collection")
 
         # Verify logger and log_job_execution are called with the error details
         mock_logger.error.assert_called_once_with(
@@ -969,14 +964,14 @@ class TestStagingMainExecution:
         mock_log_job.assert_called_once_with(
             JobStatus.failed,
             0,
-            message="Failed to retrieve the token needed to connect to the external station cadip",
+            "Failed to retrieve the token needed to connect to the external station cadip",
         )
 
         # Verify the function returns early without proceeding to Dask cluster connection
         mock_dask_cluster_connect.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_process_rspy_features_dask_connection_failure(self, mocker, staging_instance):
+    async def test_process_rspy_features_dask_connection_failure(self, mocker, staging_instance: Staging):
         """Test case where connecting to the Dask cluster raises a RuntimeError."""
         # Mock the logger
         mock_logger = mocker.patch.object(staging_instance, "logger")
@@ -1003,10 +998,10 @@ class TestStagingMainExecution:
         )
 
         # Call the async function
-        await staging_instance.process_rspy_features()
+        await staging_instance.process_rspy_features("test_collection")
 
         # Verify log_job_execution is called with the error details
-        mock_log_job.assert_called_once_with(JobStatus.failed, 0, message="Dask cluster client failed")
+        mock_log_job.assert_called_once_with(JobStatus.failed, 0, "Dask cluster client failed")
         mock_logger.error.assert_called_once_with("Failed to start the staging process")
 
         # Verify that the task submission and monitoring thread are not executed
@@ -1014,7 +1009,7 @@ class TestStagingMainExecution:
         mock_manage_dask_tasks.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_process_rspy_features_success(self, mocker, staging_instance):
+    async def test_process_rspy_features_success(self, mocker, staging_instance: Staging):
         """Test case where the entire process runs successfully."""
 
         # Mock the logger
@@ -1051,7 +1046,7 @@ class TestStagingMainExecution:
         mocker.patch.object(staging_instance, "dask_cluster_connect", return_value=mock_dask_client)
 
         # Call the async function
-        await staging_instance.process_rspy_features()
+        await staging_instance.process_rspy_features("test_collection")
 
         # Verify the function proceeds to Dask task submission
         mock_submit_tasks.assert_called_once_with(
@@ -1062,7 +1057,7 @@ class TestStagingMainExecution:
 
         # Verify the task monitoring thread is started
         mock_logger.debug.assert_any_call("Starting tasks monitoring thread")
-        mock_manage_dask_tasks.assert_called_once_with(mock_dask_client)
+        mock_manage_dask_tasks.assert_called_once_with(mock_dask_client, "test_collection")
 
         # Ensure the Dask client is closed after the tasks are processed
         mock_dask_client.close.assert_called_once()
@@ -1074,7 +1069,7 @@ class TestStagingMainExecution:
 class TestStagingPublishCatalog:
     """Class to group tests for catalog publishing after streaming was processes"""
 
-    def test_publish_rspy_feature_success(self, mocker, staging_instance):
+    def test_publish_rspy_feature_success(self, mocker, staging_instance: Staging):
         """Test successful feature publishing to the catalog."""
         feature = mocker.Mock()  # Mock the feature object
         feature.json.return_value = '{"id": "feature1", "properties": {"name": "test"}}'  # Mock the JSON serialization
@@ -1085,18 +1080,18 @@ class TestStagingPublishCatalog:
         mock_response.raise_for_status.return_value = None  # No error
         mock_post = mocker.patch("requests.post", return_value=mock_response)
 
-        result = staging_instance.publish_rspy_feature(feature)
+        result = staging_instance.publish_rspy_feature("test_collection", feature)
 
         assert result is True  # Should return True for successful publishing
         mock_post.assert_called_once_with(
-            f"{staging_instance.catalog_url}/catalog/collections/{staging_instance.catalog_collection}/items",
+            f"{staging_instance.catalog_url}/catalog/collections/test_collection/items",
             headers={"cookie": "fake-cookie", "host": "fake-host"},
             data=feature.json(),
             timeout=10,
         )
         feature.json.assert_called()  # Ensure the feature JSON serialization was called
 
-    def test_publish_rspy_feature_fail(self, mocker, staging_instance):
+    def test_publish_rspy_feature_fail(self, mocker, staging_instance: Staging):
         """Test failure during feature publishing and cleanup on error."""
         feature = mocker.Mock()
         feature.json.return_value = '{"id": "feature1", "properties": {"name": "test"}}'
@@ -1114,18 +1109,18 @@ class TestStagingPublishCatalog:
             # Mock the logger and other methods called on failure
             mock_logger = mocker.patch.object(staging_instance, "logger")
 
-            result = staging_instance.publish_rspy_feature(feature)
+            result = staging_instance.publish_rspy_feature("test_collection", feature)
 
             assert result is False  # Should return False for failure
             mock_post.assert_called_once_with(
-                f"{staging_instance.catalog_url}/catalog/collections/{staging_instance.catalog_collection}/items",
+                f"{staging_instance.catalog_url}/catalog/collections/test_collection/items",
                 headers={"cookie": "fake-cookie", "host": "fake-host"},
                 data=feature.json(),
                 timeout=10,
             )
             mock_logger.error.assert_called_once_with("Error while publishing items to rspy catalog %s", mocker.ANY)
 
-    def test_repr(self, staging_instance):
+    def test_repr(self, staging_instance: Staging):
         """Test repr method for coverage"""
         assert repr(staging_instance) == "RSPY Staging OGC API Processor"
 
@@ -1133,7 +1128,7 @@ class TestStagingPublishCatalog:
 class TestStagingUnpublishCatalog:
     """Class to group tests for catalog unpublishing after streaming failed"""
 
-    def test_unpublish_rspy_features_success(self, mocker, staging_instance):
+    def test_unpublish_rspy_features_success(self, mocker, staging_instance: Staging):
         """Test successful unpublishing feature ids to the catalog."""
         feature_ids = ["feature-1", "feature-2"]
         mock_logger = mocker.patch.object(staging_instance, "logger")
@@ -1143,23 +1138,23 @@ class TestStagingUnpublishCatalog:
         mock_delete = mocker.patch("requests.delete")
         mock_delete.return_value.status_code = 200
 
-        staging_instance.unpublish_rspy_features(feature_ids)
+        staging_instance.unpublish_rspy_features("test_collection", feature_ids)
 
         # Assert that delete was called with the correct URL and headers
         mock_delete.assert_any_call(
-            f"{staging_instance.catalog_url}/catalog/collections/{staging_instance.catalog_collection}/items/feature-1",
+            f"{staging_instance.catalog_url}/catalog/collections/test_collection/items/feature-1",
             headers={"cookie": "fake-cookie"},
             timeout=3,
         )
         mock_delete.assert_any_call(
-            f"{staging_instance.catalog_url}/catalog/collections/{staging_instance.catalog_collection}/items/feature-2",
+            f"{staging_instance.catalog_url}/catalog/collections/test_collection/items/feature-2",
             headers={"cookie": "fake-cookie"},
             timeout=3,
         )
         # Ensure no error was logged
         mock_logger.error.assert_not_called()
 
-    def test_unpublish_rspy_features_fail(self, mocker, staging_instance):
+    def test_unpublish_rspy_features_fail(self, mocker, staging_instance: Staging):
         """Test failure during feature unpublishing ."""
         feature_ids = ["feature-1"]
 
@@ -1175,17 +1170,16 @@ class TestStagingUnpublishCatalog:
             # Mock the logger and other methods called on failure
             mock_logger = mocker.patch.object(staging_instance, "logger")
 
-            staging_instance.unpublish_rspy_features(feature_ids)
+            staging_instance.unpublish_rspy_features("test_collection", feature_ids)
 
             mock_delete.assert_any_call(
-                f"{staging_instance.catalog_url}/catalog/collections/{staging_instance.catalog_collection}/\
-items/feature-1",
+                f"{staging_instance.catalog_url}/catalog/collections/test_collection/items/feature-1",
                 headers={"cookie": "fake-cookie"},
                 timeout=3,
             )
             mock_logger.error.assert_called_once_with("Error while deleting the item from rspy catalog %s", mocker.ANY)
 
-    def test_repr(self, staging_instance):
+    def test_repr(self, staging_instance: Staging):
         """Test repr method for coverage"""
         assert repr(staging_instance) == "RSPY Staging OGC API Processor"
 
@@ -1193,7 +1187,7 @@ items/feature-1",
 class TestStagingSubmitToDaskCluster:
     """Class to group tests for submiting tasks to dask cluster"""
 
-    def test_submit_tasks_to_dask_cluster_success(self, mocker, staging_instance):
+    def test_submit_tasks_to_dask_cluster_success(self, mocker, staging_instance: Staging):
         """Test the submiting tasks to dask cluster function when successful"""
         # Mock the Dask client
         mock_client = mocker.Mock()
@@ -1242,7 +1236,7 @@ class TestStagingSubmitToDaskCluster:
         # Ensure tasks were added to obj.tasks
         assert len(staging_instance.tasks) == 2
 
-    def test_submit_tasks_to_dask_cluster_failure(self, mocker, staging_instance):
+    def test_submit_tasks_to_dask_cluster_failure(self, mocker, staging_instance: Staging):
         """Test the submiting tasks to dask cluster function when fails"""
         # Mock the Dask client
         mock_client = mocker.Mock()


### PR DESCRIPTION
In RSPY-321 I asked to create the staging application as an [OGC API Processes Part 1 Core](https://ogcapi.ogc.org/processes/overview.html) implementation based on pygeoapi.

It means using as much pygeoapi code as possible. The second step is to have our staging processor to use the [signature defined and expected by pygeoapi](https://github.com/geopython/pygeoapi/blob/master/pygeoapi/process/base.py):

```python
    def execute(self, data: dict, outputs: Optional[dict] = None
                ) -> Tuple[str, Any]:
        """
        execute the process

        :param data: Dict with the input data that the process needs in order
                     to execute
        :param outputs: `dict` or `list` to optionally specify the subset of
                        required outputs - defaults to all outputs.
                        The value of any key may be an object and include the
                        property `transmissionMode` - defaults to `value`.
        :returns: tuple of MIME type and process response
                  (string or bytes, or dict)
        """
```

This PR also fixes some documentation and typing issues.

Although the formats of both the request and response of the execute endpoint do not comply to the OGC API specification, there is no change for the caller in this PR (rs-demo integration tests are not modified). This will be fixed in a future PR.

Followup of #860.