### PR TITLE
Restrict check-code-quality 'push' workflow to develop and tags

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -16,6 +16,10 @@ name: Check code quality
 
 on:
   push:
+    branches:
+      - develop # pushes on the 'develop' branch
+    tags:
+      - '**' # new git tags (including hierarchical tags like v1.0/beta)
   pull_request:
     types: [opened, synchronize, reopened]
     # run this worflow only for code/test related changes (avoid it for documentation)


### PR DESCRIPTION
This avoids having the check-code-quality workflow run twice every time we push new commits to an existing pull request.