### PR TITLE
Add missing type for stac license link

### DIFF
--- a/services/adgs/config/adgs_search_config.template.yaml
+++ b/services/adgs/config/adgs_search_config.template.yaml
@@ -34,6 +34,7 @@ template:
     - rel: license
       href: "https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf"
       title: "Legal notice on the use of Copernicus Sentinel Data and Service Information"
+      type: "application/pdf"
   providers:
     - name: "European Union/ESA/Copernicus"
       roles:

--- a/services/adgs/config/adgs_search_config.yaml
+++ b/services/adgs/config/adgs_search_config.yaml
@@ -43,6 +43,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -78,6 +79,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -114,6 +116,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -150,6 +153,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -186,6 +190,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -222,6 +227,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -258,6 +264,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -294,6 +301,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -330,6 +338,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -366,6 +375,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -402,6 +412,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -438,6 +449,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -474,6 +486,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -510,6 +523,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -546,6 +560,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -582,6 +597,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -618,6 +634,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -654,6 +671,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -690,6 +708,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -726,6 +745,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:

--- a/services/cadip/config/cadip_search_config.template.yaml
+++ b/services/cadip/config/cadip_search_config.template.yaml
@@ -34,6 +34,7 @@ template:
     - rel: license
       href: "https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf"
       title: "Legal notice on the use of Copernicus Sentinel Data and Service Information"
+      type: "application/pdf"
   providers:
     - name: "European Union/ESA/Copernicus"
       roles:

--- a/services/cadip/config/cadip_search_config.yaml
+++ b/services/cadip/config/cadip_search_config.yaml
@@ -43,6 +43,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -78,6 +79,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -113,6 +115,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -149,6 +152,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -185,6 +189,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -221,6 +226,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -257,6 +263,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -293,6 +300,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -329,6 +337,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -365,6 +374,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -401,6 +411,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -437,6 +448,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -473,6 +485,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -509,6 +522,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -545,6 +559,7 @@ collections:
   - rel: license
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
+    type: application/pdf
   providers:
   - name: European Union/ESA/Copernicus
     roles:


### PR DESCRIPTION
https://github.com/RS-PYTHON/rs-helm/pull/98

Compliance to:

> STAC-CORE-GEN-STAC-REQ-0032 – Link Type consistency with corresponding entity [Requirement]
> "type" property in "link" property shall be filled and shall reflect the actual media type of the entity it refers to.