### PR TITLE
RSPY-614 - Add describedby links to CADIP/AUXIP collections

### DIFF
--- a/services/adgs/config/adgs_search_config.template.yaml
+++ b/services/adgs/config/adgs_search_config.template.yaml
@@ -35,6 +35,10 @@ template:
       href: "https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf"
       title: "Legal notice on the use of Copernicus Sentinel Data and Service Information"
       type: "application/pdf"
+    - rel: describedby
+      href: "https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering"
+      title: "Auxiliary Data"
+      type: "text/html"
   providers:
     - name: "European Union/ESA/Copernicus"
       roles:

--- a/services/adgs/config/adgs_search_config.yaml
+++ b/services/adgs/config/adgs_search_config.yaml
@@ -44,6 +44,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -80,6 +84,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -117,6 +125,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -154,6 +166,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -191,6 +207,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -228,6 +248,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -265,6 +289,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -302,6 +330,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -339,6 +371,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -376,6 +412,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -413,6 +453,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -450,6 +494,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -487,6 +535,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -524,6 +576,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -561,6 +617,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -598,6 +658,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -635,6 +699,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -672,6 +740,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -709,6 +781,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -746,6 +822,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-AuxiliaryDataGathering
+    title: Auxiliary Data
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:

--- a/services/cadip/config/cadip_search_config.template.yaml
+++ b/services/cadip/config/cadip_search_config.template.yaml
@@ -35,6 +35,10 @@ template:
       href: "https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf"
       title: "Legal notice on the use of Copernicus Sentinel Data and Service Information"
       type: "application/pdf"
+    - rel: describedby
+      href: "https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition"
+      title: "Data Acquisition"
+      type: "text/html"
   providers:
     - name: "European Union/ESA/Copernicus"
       roles:

--- a/services/cadip/config/cadip_search_config.yaml
+++ b/services/cadip/config/cadip_search_config.yaml
@@ -44,6 +44,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -80,6 +84,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -116,6 +124,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -153,6 +165,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -190,6 +206,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -227,6 +247,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -264,6 +288,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -301,6 +329,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -338,6 +370,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -375,6 +411,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -412,6 +452,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -449,6 +493,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -486,6 +534,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -523,6 +575,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:
@@ -560,6 +616,10 @@ collections:
     href: https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
     title: Legal notice on the use of Copernicus Sentinel Data and Service Information
     type: application/pdf
+  - rel: describedby
+    href: https://sentiwiki.copernicus.eu/web/copernicus-operations#CopernicusOperations-DataAcquisition
+    title: Data Acquisition
+    type: text/html
   providers:
   - name: European Union/ESA/Copernicus
     roles:


### PR DESCRIPTION
Compliance to:

> **STAC-CORE-GEN-REQ-0040** - Reference to documentation [Recommendation]
> EOF Service STAC implementations should use a Link object with "rel": "describedby" to reference from a Collection or Item to its documentation.

https://github.com/RS-PYTHON/rs-server/pull/991
https://github.com/RS-PYTHON/rs-helm/pull/99