### PR TITLE
fix-rspy439-add-item-in-non-existing-collection

### DIFF
--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -753,6 +753,13 @@ field is not permitted also.",
 
             # The following section handles the request to create/update an item
             elif "items" in request.scope["path"]:
+                # first check if the collection exists
+                if not await self.collection_exists(request, f"{self.request_ids['owner_id']}_{collection}"):
+                    raise HTTPException(
+                        status_code=HTTP_404_NOT_FOUND,
+                        detail=f"Collection {collection} does not exist.",
+                    )
+
                 # try to get the item if it is already part from the collection
                 item = await self.get_item_from_collection(request)
 

--- a/services/catalog/tests/test_endpoints.py
+++ b/services/catalog/tests/test_endpoints.py
@@ -1612,7 +1612,6 @@ class TestCatalogPublishFeatureWithoutBucketTransferEndpoint:
         """
         ENDPOINT: PUT: /catalog/collections/{user:collection}/items/{featureID}
         """
-
         # Change correct feature collection id to match with minimal collection and post it
         a_correct_feature["collection"] = "fixture_collection"
         # Post the correct feature to catalog
@@ -1628,12 +1627,69 @@ class TestCatalogPublishFeatureWithoutBucketTransferEndpoint:
         updated_feature_sent["bbox"] = [77]
         del updated_feature_sent["collection"]
 
-        path = "/catalog/collections/fixture_owner:fixture_collections/items/NOT_FOUND_ITEM"
+        path = "/catalog/collections/fixture_owner:fixture_collection/items/NOT_FOUND_ITEM"
         feature_put_response = client.put(
             path,
             json=updated_feature_sent,
         )
         assert feature_put_response.status_code == fastapi.status.HTTP_400_BAD_REQUEST
+
+    def test_update_feature_in_non_existing_collection_fails(
+        self,
+        client,
+        a_minimal_collection,
+        a_correct_feature,
+    ):
+        """
+        ENDPOINT: PUT: /catalog/collections/{user:collection}/items/{featureID}
+        with collection as non existing collection
+        """
+        # Change correct feature collection id to match with minimal collection and post it
+        a_correct_feature["collection"] = "fixture_collection"
+        # Post the correct feature to catalog
+        feature_post_response = client.post(
+            "/catalog/collections/fixture_owner:fixture_collection/items",
+            json=a_correct_feature,
+        )
+        assert feature_post_response.status_code == fastapi.status.HTTP_201_CREATED
+
+        # Update the feature and PUT it into catalogDB
+        updated_feature_sent = copy.deepcopy(a_correct_feature)
+        updated_feature_sent["bbox"] = [-180.0, -90.0, 180.0, 90.0]
+        del updated_feature_sent["collection"]
+        time.sleep(1)
+
+        # Update feature in non existing collection
+        non_existing_collection = "NON_EXISTING_FIXTURE_COLLECTION"
+        feature_put_response = client.put(
+            f"/catalog/collections/fixture_owner:{non_existing_collection}/items/{a_correct_feature['id']}",
+            json=updated_feature_sent,
+        )
+
+        assert feature_put_response.status_code == fastapi.status.HTTP_404_NOT_FOUND
+        assert feature_put_response.json() == f"Collection {non_existing_collection} does not exist."
+
+    def test_add_feature_in_non_existing_collection_fails(
+        self,
+        client,
+        a_minimal_collection,
+        a_correct_feature,
+    ):
+        """
+        ENDPOINT: POST: /catalog/collections/{user:collection}/items/
+        with collection as non existing collection
+        """
+        # Change correct feature collection id to match with minimal collection and post it
+        a_correct_feature["collection"] = "fixture_collection"
+        # Post the correct feature to catalog
+        non_existing_collection = "NON_EXISTING_FIXTURE_COLLECTION"
+        feature_post_response = client.post(
+            f"/catalog/collections/fixture_owner:{non_existing_collection}/items",
+            json=a_correct_feature,
+        )
+
+        assert feature_post_response.status_code == fastapi.status.HTTP_404_NOT_FOUND
+        assert feature_post_response.json() == f"Collection {non_existing_collection} does not exist."
 
     def test_update_with_an_incorrect_feature(self, client, a_minimal_collection, a_correct_feature):
         """Testing POST feature endpoint with a wrong-formatted field (BBOX)."""

--- a/services/catalog/tests/test_endpoints.py
+++ b/services/catalog/tests/test_endpoints.py
@@ -1644,26 +1644,13 @@ class TestCatalogPublishFeatureWithoutBucketTransferEndpoint:
         ENDPOINT: PUT: /catalog/collections/{user:collection}/items/{featureID}
         with collection as non existing collection
         """
-        # Change correct feature collection id to match with minimal collection and post it
+        # Change correct feature collection id to match with minimal collection
         a_correct_feature["collection"] = "fixture_collection"
-        # Post the correct feature to catalog
-        feature_post_response = client.post(
-            "/catalog/collections/fixture_owner:fixture_collection/items",
-            json=a_correct_feature,
-        )
-        assert feature_post_response.status_code == fastapi.status.HTTP_201_CREATED
-
-        # Update the feature and PUT it into catalogDB
-        updated_feature_sent = copy.deepcopy(a_correct_feature)
-        updated_feature_sent["bbox"] = [-180.0, -90.0, 180.0, 90.0]
-        del updated_feature_sent["collection"]
-        time.sleep(1)
-
-        # Update feature in non existing collection
+        # Put feature in non existing collection
         non_existing_collection = "NON_EXISTING_FIXTURE_COLLECTION"
         feature_put_response = client.put(
             f"/catalog/collections/fixture_owner:{non_existing_collection}/items/{a_correct_feature['id']}",
-            json=updated_feature_sent,
+            json=a_correct_feature,
         )
 
         assert feature_put_response.status_code == fastapi.status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Fix for [Catalog] Issue while adding items to a non existing collection: https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-439

The issue applies to both updating / adding items ( PUT / POST ) to a non existing collection. HTTPException with status HTTP_404_NOT_FOUND will be raised when the collection in the request does not exist.
