### PR TITLE
RSPY-635 - Use application/geo+json content-type for relevant endpoints

### DIFF
--- a/services/adgs/rs_server_adgs/api/adgs_search.py
+++ b/services/adgs/rs_server_adgs/api/adgs_search.py
@@ -59,6 +59,7 @@ from rs_server_common.stac_api_common import (
 )
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils import validate_inputs_format, validate_sort_input
+from stac_fastapi.api.models import GeoJSONResponse
 
 # pylint: disable=duplicate-code # with cadip_search
 
@@ -202,7 +203,7 @@ async def get_adgs_collection(
     return await request.app.state.pgstac_client.get_collection(collection_id, request)
 
 
-@router.get("/auxip/collections/{collection_id}/items")
+@router.get(path="/auxip/collections/{collection_id}/items", response_class=GeoJSONResponse)
 @handle_exceptions
 async def get_adgs_collection_items(
     request: Request,
@@ -248,7 +249,7 @@ async def get_adgs_collection_items(
     )
 
 
-@router.get("/auxip/collections/{collection_id}/items/{item_id}")
+@router.get(path="/auxip/collections/{collection_id}/items/{item_id}", response_class=GeoJSONResponse)
 @handle_exceptions
 async def get_adgs_collection_specific_item(
     request: Request,

--- a/services/cadip/rs_server_cadip/api/cadip_search.py
+++ b/services/cadip/rs_server_cadip/api/cadip_search.py
@@ -71,6 +71,7 @@ from rs_server_common.utils.utils import (
     validate_sort_input,
     validate_str_list,
 )
+from stac_fastapi.api.models import GeoJSONResponse
 
 # pylint: disable=duplicate-code # with adgs_search
 
@@ -352,7 +353,7 @@ async def get_cadip_collection(
     return await request.app.state.pgstac_client.get_collection(collection_id, request)
 
 
-@router.get("/cadip/collections/{collection_id}/items")
+@router.get(path="/cadip/collections/{collection_id}/items", response_class=GeoJSONResponse)
 @handle_exceptions
 async def get_cadip_collection_items(
     request: Request,
@@ -404,7 +405,7 @@ async def get_cadip_collection_items(
     )
 
 
-@router.get("/cadip/collections/{collection_id}/items/{session_id}")
+@router.get(path="/cadip/collections/{collection_id}/items/{session_id}", response_class=GeoJSONResponse)
 @handle_exceptions
 async def get_cadip_collection_item_details(
     request: Request,

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -21,6 +21,8 @@ import requests
 import responses
 import yaml
 from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
+from httpx import Response
 from pydantic import ValidationError
 from rs_server_adgs import adgs_utils
 from rs_server_adgs.adgs_utils import auxip_map_mission
@@ -137,7 +139,7 @@ class TestLandingPagesEndpoints:
         [(ROUTER_PREFIX_CADIP, "/cadip", "/cadip/collections"), (ROUTER_PREFIX_AUXIP, "/auxip", "/auxip/collections")],
         indirect=["fastapi_app"],
     )
-    def test_local_landing_pages(self, client, endpoint, collection_link):
+    def test_local_landing_pages(self, client: TestClient, endpoint, collection_link):
         """
         Unit test for checking the structure and links of the landing page.
 
@@ -403,7 +405,7 @@ class TestFeatureOdataStacMapping:
     @pytest.mark.parametrize("fastapi_app", [ROUTER_PREFIX_CADIP], indirect=["fastapi_app"])
     def test_cadip_feature_mapping(
         self,
-        client,
+        client: TestClient,
         mock_token_validation,
         cadip_feature,
         cadip_session_response,
@@ -428,9 +430,10 @@ class TestFeatureOdataStacMapping:
             json=cadip_file_response,
             status=200,
         )
-        response = client.get("/cadip/collections/cadip_session_by_id/items/S1A_20200105072204051312").json()
+        response: Response = client.get("/cadip/collections/cadip_session_by_id/items/S1A_20200105072204051312")
         # Assert that receive odata response is correctly mapped to stac feature.
-        assert response == cadip_feature, "Features don't match"
+        assert response.json() == cadip_feature, "Features don't match"
+        assert response.headers.get("Content-Type") == "application/geo+json"
 
     @pytest.mark.unit
     @responses.activate
@@ -454,7 +457,7 @@ class TestFeatureOdataStacMapping:
     @pytest.mark.unit
     @responses.activate
     @pytest.mark.parametrize("fastapi_app", [ROUTER_PREFIX_AUXIP], indirect=["fastapi_app"])
-    def test_adgs_feature_mapping(self, client, mock_token_validation, adgs_feature, adgs_response):
+    def test_adgs_feature_mapping(self, client: TestClient, mock_token_validation, adgs_feature, adgs_response):
         """Test mapping of an adgs reponse with expanded attributes"""
         mock_token_validation()
         responses.add(
@@ -466,11 +469,12 @@ class TestFeatureOdataStacMapping:
             json=adgs_response,
             status=200,
         )
-        response = client.get(
+        response: Response = client.get(
             "/auxip/collections/s2_adgs2_AUX_OBMEMC/items/S1A_OPER_MPL_ORBPRE_20210214T021411_20210221T021411_0001.EOF",
-        ).json()
+        )
         # Assert that receive odata response is correctly mapped to stac feature.
-        assert response == adgs_feature, "Features don't match"
+        assert response.json() == adgs_feature, "Features don't match"
+        assert response.headers.get("Content-Type") == "application/geo+json"
 
     @pytest.mark.unit
     @responses.activate
@@ -596,7 +600,7 @@ class TestFeatureCollectionOdataStacMapping:
     @pytest.mark.parametrize("fastapi_app", [ROUTER_PREFIX_CADIP], indirect=["fastapi_app"])
     def test_cadip_feature_collection_mapping(
         self,
-        client,
+        client: TestClient,
         mock_token_validation,
         cadip_feature,
         cadip_file_response,
@@ -621,15 +625,23 @@ class TestFeatureCollectionOdataStacMapping:
             json=cadip_file_response,
             status=200,
         )
-        response = client.get("/cadip/collections/cadip_session_by_id/items").json()
+        response: Response = client.get("/cadip/collections/cadip_session_by_id/items")
+        items = response.json()
         # Assert that receive odata response is correctly mapped to stac feature.
-        assert response["type"] == "FeatureCollection", "Type doesn't match"
-        assert response["features"] == [cadip_feature], "Features don't match"
+        assert items["type"] == "FeatureCollection", "Type doesn't match"
+        assert items["features"] == [cadip_feature], "Features don't match"
+        assert response.headers.get("Content-Type") == "application/geo+json"
 
     @pytest.mark.unit
     @responses.activate
     @pytest.mark.parametrize("fastapi_app", [ROUTER_PREFIX_AUXIP], indirect=["fastapi_app"])
-    def test_adgs_feature_collection_mapping(self, client, mock_token_validation, adgs_feature, adgs_response):
+    def test_adgs_feature_collection_mapping(
+        self,
+        client: TestClient,
+        mock_token_validation,
+        adgs_feature,
+        adgs_response,
+    ):
         """Test mapping of an adgs reponse with expanded attributes"""
         mock_token_validation()
         responses.add(
@@ -640,10 +652,12 @@ class TestFeatureCollectionOdataStacMapping:
             json=adgs_response,
             status=200,
         )
-        response = client.get("/auxip/collections/s2_adgs2_AUX_OBMEMC/items").json()
+        response: Response = client.get("/auxip/collections/s2_adgs2_AUX_OBMEMC/items")
+        items = response.json()
         # Assert that receive odata response is correctly mapped to stac feature.
-        assert response["type"] == "FeatureCollection", "Type doesn't match"
-        assert response["features"] == [adgs_feature], "Features don't match"
+        assert items["type"] == "FeatureCollection", "Type doesn't match"
+        assert items["features"] == [adgs_feature], "Features don't match"
+        assert response.headers.get("Content-Type") == "application/geo+json"
 
     @pytest.mark.unit
     @responses.activate


### PR DESCRIPTION
Same problem (and same fix) than https://github.com/RS-PYTHON/rs-server/pull/617, but for AUXIP/CADIP