### PR TITLE
RSPY-636 - Return HTTP 400 for CADIP/AUXIP request validation errors

### DIFF
--- a/services/common/rs_server_common/fastapi_app.py
+++ b/services/common/rs_server_common/fastapi_app.py
@@ -38,6 +38,7 @@ from rs_server_common.schemas.health_schema import HealthSchema
 from rs_server_common.utils import opentelemetry
 from rs_server_common.utils.logging import Logging
 from stac_fastapi.api.app import StacApi
+from stac_fastapi.api.errors import add_exception_handlers
 from stac_fastapi.api.middleware import ProxyHeaderMiddleware
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
 from stac_fastapi.api.routes import add_route_dependencies
@@ -76,7 +77,7 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
     pause: int = 3,
     timeout: int = None,
     router_prefix: str = "",
-):  # pylint: disable=too-many-arguments
+) -> FastAPI:  # pylint: disable=too-many-arguments
     """
     Init the FastAPI application.
     See: https://praciano.com.br/fastapi-and-async-sqlalchemy-20-with-pytest-done-right.html
@@ -207,6 +208,10 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
     service = router_prefix.strip("/").title()
     app.state.pgstac_client.title = f"RS-PYTHON {service} collections"
     app.state.pgstac_client.description = f"{service} collections of Copernicus Reference System Python"
+    # By default FastAPI will return 422 status codes for invalid requests
+    # But the STAC api spec suggests returning a 400 in this case
+    # TODO remove this also
+    add_exception_handlers(app, {})
 
     dependencies = []
     if settings.CLUSTER_MODE:

--- a/tests/app.py
+++ b/tests/app.py
@@ -16,7 +16,7 @@
 
 import os
 
-from fastapi import Request
+from fastapi import FastAPI, Request
 from rs_server_adgs.api.adgs_search import MockPgstacAdgs
 from rs_server_adgs.fastapi.adgs_routers import adgs_routers
 from rs_server_cadip.api.cadip_search import MockPgstacCadip
@@ -42,10 +42,10 @@ class MockPgstacTest(MockPgstac):
         raise RuntimeError(f"Invalid router_prefix or endpoint: {router_prefix!r} / {endpoint!r}")
 
 
-def init_app(router_prefix: str = ""):
+def init_app(router_prefix: str = "") -> FastAPI:
     """Run all routers for the tests."""
     routers = adgs_routers + cadip_routers
-    app = init_app_with_args(
+    app: FastAPI = init_app_with_args(
         api_version="test",
         routers=routers,
         init_db=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ import pytest
 import responses
 import yaml
 from dotenv import load_dotenv
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from rs_server_common.authentication import oauth2  # pylint: disable=ungrouped-imports
 from rs_server_common.authentication.authentication_to_external import (
@@ -215,7 +216,7 @@ def fastapi_app_(  # pylint: disable=too-many-arguments
 
 
 @pytest.fixture(name="client")
-def client_(fastapi_app):
+def client_(fastapi_app: FastAPI):
     """Test the FastAPI application, opens the database session."""
     with TestClient(fastapi_app) as client:
         yield client
@@ -229,7 +230,7 @@ def create_tables(client):  # pylint: disable=unused-argument
 
 
 @pytest.fixture(scope="function", autouse=True)
-def session_override(client, fastapi_app):  # pylint: disable=unused-argument
+def session_override(client, fastapi_app: FastAPI):  # pylint: disable=unused-argument
     """Override the default database session"""
 
     # pylint: disable=duplicate-code

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -823,10 +823,10 @@ class TestFeatureCollectionOdataStacMapping:
             "/cadip/collections/cadip_session_by_id/items?limit=0",
         ],
     )
-    def test_invalid_limit_values(self, client, endpoint):
+    def test_invalid_limit_values(self, client: TestClient, endpoint: str):
         """Test endpoint call with invalid limits (str, negative, 0)"""
         response = client.get(endpoint)
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["detail"][0]["msg"] in (
             "Input should be a valid integer, unable to parse string as an integer",
             "Input should be greater than 0",


### PR DESCRIPTION
By default FastAPI will return 422 status codes for invalid requests
But the STAC api spec suggests returning a 400 in this case