### PR TITLE
RSPY-646 - Remove the 100 characters limit

### DIFF
--- a/services/adgs/rs_server_adgs/api/adgs_search.py
+++ b/services/adgs/rs_server_adgs/api/adgs_search.py
@@ -195,7 +195,7 @@ async def get_allowed_adgs_collections(request: Request):
 @handle_exceptions
 async def get_adgs_collection(
     request: Request,
-    collection_id: Annotated[str, FPath(title="AUXIP{} collection ID.", max_length=100, description="E.G. ")],
+    collection_id: Annotated[str, FPath(title="AUXIP{} collection ID.", description="E.G. ")],
 ) -> list[dict] | dict | stac_pydantic.Collection:
     """Return a specific ADGS collection."""
     logger.info(f"Starting {request.url.path}")
@@ -225,7 +225,7 @@ async def get_adgs_collection_items(
 
     Args:
         collection_id (str): AUXIP collection ID. Must be a valid collection identifier
-                             (e.g., 'ins_s1'). Maximum length of 100 characters.
+                             (e.g., 'ins_s1').
 
     Returns:
         list[dict]: A FeatureCollection of items belonging to the specified collection, or an
@@ -253,12 +253,11 @@ async def get_adgs_collection_items(
 @handle_exceptions
 async def get_adgs_collection_specific_item(
     request: Request,
-    collection_id: Annotated[str, FPath(title="AUXIP{} collection ID.", max_length=100, description="E.G. ")],
+    collection_id: Annotated[str, FPath(title="AUXIP{} collection ID.", description="E.G. ")],
     item_id: Annotated[
         str,
         FPath(
             title="AUXIP Id",
-            max_length=100,
             description="E.G. S1A_OPER_MPL_ORBPRE_20210214T021411_20210221T021411_0001.EOF",
         ),
     ],
@@ -272,10 +271,9 @@ async def get_adgs_collection_specific_item(
 
     Args:
     - collection_id (str): AUXIP collection ID. Must be a valid collection identifier
-            (e.g., 'ins_s1'). Maximum length of 100 characters.
+            (e.g., 'ins_s1').
     - item_id (str): AUXIP item ID. Must be a valid item identifier
             (e.g., 'S1A_OPER_MPL_ORBPRE_20210214T021411_20210221T021411_0001.EOF').
-            Maximum length of 100 characters.
 
     Returns:
     - dict: A JSON object containing details of the specified item, or an error


### PR DESCRIPTION
Remove the 100 characters limit so that we can retrieve `S3A_AX___OSF_AX_20160216T192404_99991231T235959_20220330T090651___________________EUM_O_AL_001.SEN3.zip` from ADGS (103 characters).

There is no limit specified in the AUXIP ICD.