### PR TITLE
RSPY-611 - Use our own STAC extensions

### DIFF
--- a/docs/doc/users/functionalities.adoc
+++ b/docs/doc/users/functionalities.adoc
@@ -42,7 +42,6 @@ GET /cadip/station123/cadu/search?datetime=2023-01-01T00:00:00Z/2023-01-02T23:59
         "cadip:final_block": true,
         "cadip:block_number": 1,
         "cadip:channel": 2,
-        "cadip:session_id": "S1A_20170501121534062343",
     },
     "links": [],
     "assets": {

--- a/docs/doc/users/functionalities.md
+++ b/docs/doc/users/functionalities.md
@@ -59,7 +59,6 @@ search files comming from multiple acquisition sessions.
             "cadip:final_block": true,
             "cadip:block_number": 1,
             "cadip:channel": 2,
-            "cadip:session_id": "S1A_20170501121534062343",
         },
         "links": [],
         "assets": {

--- a/services/adgs/config/ODataToSTAC_template.json
+++ b/services/adgs/config/ODataToSTAC_template.json
@@ -1,6 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": [
+        "https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],

--- a/services/adgs/config/adgs_search_config.template.yaml
+++ b/services/adgs/config/adgs_search_config.template.yaml
@@ -18,6 +18,7 @@ template:
   query:
   stac_extensions:
     [
+      "https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json",
       "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
       "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json",

--- a/services/adgs/config/adgs_search_config.yaml
+++ b/services/adgs/config/adgs_search_config.yaml
@@ -22,6 +22,7 @@ collections:
   station: adgs
   query: null
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -62,6 +63,7 @@ collections:
   station: adgs2
   query: null
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -103,6 +105,7 @@ collections:
   query:
     productType: AUX_PP2
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -144,6 +147,7 @@ collections:
   query:
     productType: OPER_AUX_ECMWFD_PDMC
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -185,6 +189,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -226,6 +231,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC_PDMC
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -267,6 +273,7 @@ collections:
   query:
     productType: OPER_AUX_PREORB_OPOD
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -308,6 +315,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPOD
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -349,6 +357,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPODs
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -390,6 +399,7 @@ collections:
   query:
     productType: OPER_MPL_ORBPRE
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -431,6 +441,7 @@ collections:
   query:
     productType: OPER_MPL_ORBSCT
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -472,6 +483,7 @@ collections:
   query:
     productType: AUX_PP2
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -513,6 +525,7 @@ collections:
   query:
     productType: OPER_AUX_ECMWFD_PDMC
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -554,6 +567,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -595,6 +609,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC_PDMC
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -636,6 +651,7 @@ collections:
   query:
     productType: OPER_AUX_PREORB_OPOD
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -677,6 +693,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPOD
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -718,6 +735,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPODs
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -759,6 +777,7 @@ collections:
   query:
     productType: OPER_MPL_ORBPRE
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -800,6 +819,7 @@ collections:
   query:
     productType: OPER_MPL_ORBSCT
   stac_extensions:
+  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json

--- a/services/cadip/config/ODataToSTAC_template.json
+++ b/services/cadip/config/ODataToSTAC_template.json
@@ -1,6 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": [
+        "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json"
     ],
     "type": "Feature",
@@ -16,8 +17,7 @@
         "cadip:retransfer": "PLACEHOLDER",
         "cadip:final_block": "PLACEHOLDER",
         "cadip:block_number": "PLACEHOLDER",
-        "cadip:channel": "PLACEHOLDER",
-        "cadip:session_id": "PLACEHOLDER"
+        "cadip:channel": "PLACEHOLDER"
     },
     "links": [],
     "assets": {

--- a/services/cadip/config/cadip_search_config.template.yaml
+++ b/services/cadip/config/cadip_search_config.template.yaml
@@ -18,6 +18,7 @@ template:
   query:
   stac_extensions:
     [
+      "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
       "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
       "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json",

--- a/services/cadip/config/cadip_search_config.yaml
+++ b/services/cadip/config/cadip_search_config.yaml
@@ -22,6 +22,7 @@ collections:
   station: cadip
   query: null
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -62,6 +63,7 @@ collections:
   station: mti
   query: null
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -102,6 +104,7 @@ collections:
   station: sgs
   query: null
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -143,6 +146,7 @@ collections:
   query:
     Satellite: S1A, S1B, S1C
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -184,6 +188,7 @@ collections:
   query:
     Satellite: S2A, S2B, S2C
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -225,6 +230,7 @@ collections:
   query:
     Satellite: S3A, S3B
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -266,6 +272,7 @@ collections:
   query:
     Satellite: S5P
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -307,6 +314,7 @@ collections:
   query:
     Satellite: S1A, S1B, S1C
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -348,6 +356,7 @@ collections:
   query:
     Satellite: S2A, S2B, S2C
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -389,6 +398,7 @@ collections:
   query:
     Satellite: S3A, S3B
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -430,6 +440,7 @@ collections:
   query:
     Satellite: S5P
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -471,6 +482,7 @@ collections:
   query:
     Satellite: S1A, S1B, S1C
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -512,6 +524,7 @@ collections:
   query:
     Satellite: S2A, S2B, S2C
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -553,6 +566,7 @@ collections:
   query:
     Satellite: S3A, S3B
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -594,6 +608,7 @@ collections:
   query:
     Satellite: S5P
   stac_extensions:
+  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json

--- a/services/cadip/config/cadip_session_ODataToSTAC_template.json
+++ b/services/cadip/config/cadip_session_ODataToSTAC_template.json
@@ -1,6 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": [
+        "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],

--- a/services/cadip/config/cadip_stac_mapper.json
+++ b/services/cadip/config/cadip_stac_mapper.json
@@ -5,7 +5,6 @@
     "cadip:final_block": "FinalBlock",
     "cadip:block_number": "BlockNumber",
     "cadip:channel": "Channel",
-    "cadip:session_id": "SessionId",
     "created": "PublicationDate",
     "eviction_datetime": "EvictionDate",
     "file:size": "Size",

--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -429,10 +429,13 @@ collections/{user}:{collection_id}/items/{self.request_ids['item_id']}/download/
                     status_code=HTTP_400_BAD_REQUEST,
                 ) from exc
 
-        # 3 - include new stac extension if not present
-        new_stac_extension = "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json"
-        if new_stac_extension not in content["stac_extensions"]:
-            content["stac_extensions"].append(new_stac_extension)
+        # 3 - include new stac extensions if not present
+        for new_stac_extension in [
+            "https://rs-python.github.io/ownership-stac-extension/v1.0.0/schema.json",
+            "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        ]:
+            if new_stac_extension not in content["stac_extensions"]:
+                content["stac_extensions"].append(new_stac_extension)
 
         # 4 - bucket handling
         self.s3_bucket_handling(files_s3_key, item, request)

--- a/tests/resources/endpoints/adgs_feature.json
+++ b/tests/resources/endpoints/adgs_feature.json
@@ -48,6 +48,7 @@
         }
     ],
     "stac_extensions": [
+        "https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],

--- a/tests/resources/endpoints/cadip_feature.json
+++ b/tests/resources/endpoints/cadip_feature.json
@@ -37,7 +37,6 @@
             "cadip:final_block": false,
             "cadip:block_number": 1,
             "cadip:channel": 1,
-            "cadip:session_id": "S1A_20200105072204051312",
             "created": "2020-01-05T18:52:29.165Z",
             "eviction_datetime": "2020-01-05T18:52:29.165Z",
             "file:size": 42
@@ -53,7 +52,6 @@
             "cadip:final_block": false,
             "cadip:block_number": 1,
             "cadip:channel": 1,
-            "cadip:session_id": "S1A_20200105072204051312",
             "created": "2020-01-05T18:52:32.165Z",
             "eviction_datetime": "2020-01-05T18:52:32.165Z",
             "file:size": 51
@@ -82,6 +80,7 @@
         }
     ],
     "stac_extensions": [
+        "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],


### PR DESCRIPTION
Include our own STAC extensions:

https://github.com/RS-PYTHON/download-stac-api-extension
https://github.com/RS-PYTHON/auxip-stac-extension
https://github.com/RS-PYTHON/cadip-stac-extension
https://github.com/RS-PYTHON/ownership-stac-extension