### PR TITLE
RSPY-641 - Support 'sortby=properties.*' standard format

### DIFF
--- a/services/adgs/rs_server_adgs/api/adgs_search.py
+++ b/services/adgs/rs_server_adgs/api/adgs_search.py
@@ -247,7 +247,7 @@ async def get_adgs_collection_items(
         datetime=datetime,
         filter=filter_,
         filter_lang=filter_lang,
-        sortby=sortby,
+        sortby=[sortby] if sortby else None,
         limit=limit,
         page=page,
     )

--- a/services/cadip/rs_server_cadip/api/cadip_search.py
+++ b/services/cadip/rs_server_cadip/api/cadip_search.py
@@ -403,7 +403,7 @@ async def get_cadip_collection_items(
         datetime=datetime,
         filter=filter_,
         filter_lang=filter_lang,
-        sortby=sortby,
+        sortby=[sortby] if sortby else None,
         limit=limit,
         page=page,
     )

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -917,11 +917,15 @@ def sort_feature_collection(item_collection: ItemCollection, sortby: str) -> Ite
     sortby = sortby.strip("'\"")
     direction, attribute = sortby[:1], sortby[1:]
 
+    # From STAC API Sort extension:
+    # Implementers may choose to require fields in Item Properties to be prefixed with properties. or not,
+    # or support use of both the prefixed and non-prefixed name, e.g., properties.datetime or datetime
+
     # Try to sort by 'properties' first, then fallback to the 'feature' itself
     def get_sort_key(item):
         # Check if the attribute exists in properties, else use item directly
-        if hasattr(item.properties, attribute):
-            return getattr(item.properties, attribute)
+        if hasattr(item.properties, attribute.replace("properties.", "")):
+            return getattr(item.properties, attribute.replace("properties.", ""))
         if hasattr(item, attribute):
             return getattr(item, attribute)
         # Otherwise, check if the attribute exists in any asset

--- a/services/common/rs_server_common/utils/utils.py
+++ b/services/common/rs_server_common/utils/utils.py
@@ -222,5 +222,5 @@ def validate_sort_input(sortby: str):
     """Used to transform stac sort parameter to odata type.
     -datetime = startTimeFromAscendingNode DESC.
     """
-    sortby = sortby.strip("'\"").lower()
-    return [(sortby[1:], "DESC" if sortby[0] == "-" else "ASC")]
+    sortby = sortby.strip("'\"").lower().replace("properties.", "")
+    return [(sortby[1:] if sortby[0] in ["-", "+"] else sortby, "DESC" if sortby[0] == "-" else "ASC")]


### PR DESCRIPTION
The first part of allowing to search auxiliary data using the processor's CQL2 filter is to support this syntax:

https://rspy.ops.rs-python.eu/auxip/collections/S3-AX___OSF_AX/items?sortby=-properties.created
https://rspy.ops.rs-python.eu/auxip/search?collections=S3-AX___OSF_AX&items?sortby=-properties.created
