### PR TITLE
RSPY-641 - Add CQL2 temporal operators support to rs-server-auxip

### DIFF
--- a/services/adgs/config/adgs_ws_config.template.yaml
+++ b/services/adgs/config/adgs_ws_config.template.yaml
@@ -128,6 +128,21 @@ template:
             - "ContentDate/Start gt {Start#to_iso_utc_datetime}"
             - "ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}"
             - "ContentDate/Stop lt {Stop#to_iso_utc_datetime}"
+            - "{t_before}"
+            - "{t_after}"
+            - "{t_meets}"
+            - "{t_metby}"
+            - "{t_overlaps}"
+            - "{t_overlappedby}"
+            - "{t_starts}"
+            - "{t_startedby}"
+            - "{t_during}"
+            - "{t_contains}"
+            - "{t_finishes}"
+            - "{t_finishedby}"
+            - "{t_equals}"
+            - "{t_disjoint}"
+            - "{t_intersects}"
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:

--- a/services/adgs/config/adgs_ws_config.yaml
+++ b/services/adgs/config/adgs_ws_config.yaml
@@ -137,6 +137,21 @@ adgs:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
@@ -282,6 +297,21 @@ adgs2:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:

--- a/services/adgs/config/adgs_ws_config_token_module.template.yaml
+++ b/services/adgs/config/adgs_ws_config_token_module.template.yaml
@@ -112,6 +112,21 @@ template:
             - "ContentDate/Start gt {Start#to_iso_utc_datetime}"
             - "ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}"
             - "ContentDate/Stop lt {Stop#to_iso_utc_datetime}"
+            - "{t_before}"
+            - "{t_after}"
+            - "{t_meets}"
+            - "{t_metby}"
+            - "{t_overlaps}"
+            - "{t_overlappedby}"
+            - "{t_starts}"
+            - "{t_startedby}"
+            - "{t_during}"
+            - "{t_contains}"
+            - "{t_finishes}"
+            - "{t_finishedby}"
+            - "{t_equals}"
+            - "{t_disjoint}"
+            - "{t_intersects}"
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:

--- a/services/adgs/config/adgs_ws_config_token_module.yaml
+++ b/services/adgs/config/adgs_ws_config_token_module.yaml
@@ -122,6 +122,21 @@ adgs:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:
@@ -252,6 +267,21 @@ adgs2:
           - ContentDate/Start gt {Start#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
           - ContentDate/Stop lt {Stop#to_iso_utc_datetime}
+          - '{t_before}'
+          - '{t_after}'
+          - '{t_meets}'
+          - '{t_metby}'
+          - '{t_overlaps}'
+          - '{t_overlappedby}'
+          - '{t_starts}'
+          - '{t_startedby}'
+          - '{t_during}'
+          - '{t_contains}'
+          - '{t_finishes}'
+          - '{t_finishedby}'
+          - '{t_equals}'
+          - '{t_disjoint}'
+          - '{t_intersects}'
     sort:
       sort_by_tpl: '&$orderby={sort_param} {sort_order}'
       sort_param_mapping:

--- a/services/adgs/rs_server_adgs/api/adgs_search.py
+++ b/services/adgs/rs_server_adgs/api/adgs_search.py
@@ -87,6 +87,7 @@ class MockPgstacAdgs(MockPgstac):
             select_config=select_config,
             stac_to_odata=stac_to_odata,
             map_mission=auxip_map_mission,
+            temporal_mapping={"start_datetime": "ContentDate/Start", "end_datetime": "ContentDate/End"},
         )
 
         # Default sortby value

--- a/services/cadip/rs_server_cadip/api/cadip_search.py
+++ b/services/cadip/rs_server_cadip/api/cadip_search.py
@@ -105,6 +105,8 @@ class MockPgstacCadip(MockPgstac):
             select_config=select_config,
             stac_to_odata=stac_to_odata,
             map_mission=cadip_map_mission,
+            # impossible to define a temporal OData mapping that would be
+            # {"start_datetime": "DownlinkStart", "end_datetime": "max(Files.PublicationDate)"}
         )
 
         # Default sortby value

--- a/services/cadip/rs_server_cadip/cadip_utils.py
+++ b/services/cadip/rs_server_cadip/cadip_utils.py
@@ -32,6 +32,7 @@ from fastapi import HTTPException, status
 from rs_server_common.rspy_models import Item
 from rs_server_common.stac_api_common import map_stac_platform
 from rs_server_common.utils.logging import Logging
+from rs_server_common.utils.utils import strftime_millis
 from stac_pydantic import ItemCollection, ItemProperties
 from stac_pydantic.shared import Asset
 
@@ -227,7 +228,7 @@ def link_assets_to_session(session_features: list[Item], asset_items: list[dict]
             # Using one of the fields REQUIRES inclusion of the other field as well to enable a user to search STAC
             # records by the provided times. So if you use start_datetime you need to add end_datetime and vice-versa.
             if start_date and end_date:
-                properties.end_datetime = end_date.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"  # type: ignore
+                properties.end_datetime = strftime_millis(end_date)  # type: ignore
             elif start_date or end_date:
                 logger.warning(f"{feature.id} has only one time range property: {start_date}/{end_date}")
                 properties.start_datetime = None

--- a/services/common/rs_server_common/data_retrieval/eodag_provider.py
+++ b/services/common/rs_server_common/data_retrieval/eodag_provider.py
@@ -35,6 +35,7 @@ from rs_server_common.authentication.external_authentication_config import (
 )
 from rs_server_common.authentication.token_auth import get_station_token
 from rs_server_common.settings import env_bool
+from rs_server_common.stac_cql2 import temporal_operations
 from rs_server_common.utils.logging import Logging
 
 from .provider import CreateProviderFailed, Provider, SearchProductFailed
@@ -152,7 +153,7 @@ class EodagProvider(Provider):
         self.client.set_preferred_provider(self.provider)
         self.client.authenticate_provider(self.provider, external_config)
 
-    def _specific_search(self, **kwargs) -> SearchResult | list:
+    def _specific_search(self, **kwargs) -> SearchResult | list:  # pylint: disable=too-many-branches,too-many-locals
         """
         Conducts a search for products using the specified OData arguments.
 
@@ -207,6 +208,11 @@ class EodagProvider(Provider):
                     "StopPublicationDate": end,
                 },
             )
+
+        for op in temporal_operations:
+            if query := kwargs.pop(op, None):
+                mapped_search_args[op] = query
+
         max_items_allowed = int(self.client.providers_config[self.provider].search.pagination["max_items_per_page"])
         if int(kwargs["items_per_page"]) > max_items_allowed:
             logger.warning(
@@ -216,7 +222,7 @@ class EodagProvider(Provider):
             logger.warning(f"Number of items per page was set to {max_items_allowed - 1}.")
             kwargs["items_per_page"] = max_items_allowed - 1
         try:
-            logger.info(f"Searching from {self.provider} with parameters {mapped_search_args}")
+            logger.info(f"Searching from {self.provider} with parameters {mapped_search_args} and kwargs {kwargs}")
             # Start search -> user defined search params in mapped_search_args (id), pagination in kwargs (top, limit).
             # search_method = self.client.search if "session" not in self.provider else self.client.search_iter_page
             products = self.client.search(

--- a/services/common/rs_server_common/rspy_models.py
+++ b/services/common/rs_server_common/rspy_models.py
@@ -25,6 +25,7 @@ from typing import Any
 import stac_pydantic
 from geojson_pydantic import FeatureCollection
 from pydantic import ConfigDict, Field
+from rs_server_common.utils.utils import strftime_millis
 from stac_pydantic.links import Links
 from stac_pydantic.shared import StacBaseModel, StacCommonMetadata
 
@@ -52,10 +53,7 @@ class ItemProperties(WrapStacCommonMetadata):
 
     def __init__(self, **data: Any):
         """Force convert datetime to str if any in init."""
-        data = {
-            key: (value.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z" if isinstance(value, datetime) else value)
-            for key, value in data.items()
-        }
+        data = {key: (strftime_millis(value) if isinstance(value, datetime) else value) for key, value in data.items()}
 
         # Call the parent class's initializer
         super().__init__(**data)

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=too-many-lines
+
 """Module to share common functionalities for validating / creating stac items"""
 import copy
 import json
+import re
 import threading
 import traceback
 import urllib.parse
@@ -43,6 +46,7 @@ from fastapi.datastructures import QueryParams
 from pydantic import BaseModel, Field, ValidationError
 from rs_server_common import settings
 from rs_server_common.rspy_models import Item, ItemCollection
+from rs_server_common.stac_cql2 import temporal_op_query, temporal_operations
 from rs_server_common.utils import utils2
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils import (
@@ -60,7 +64,7 @@ logger = Logging.default(__name__)
 
 
 def log_http_exception(*args, **kwargs) -> HTTPException:
-    """Log error and return an HTTP execption to be raised by the caller"""
+    """Log error and return an HTTP exception to be raised by the caller"""
     return utils2.log_http_exception(logger, *args, **kwargs)
 
 
@@ -81,9 +85,8 @@ FilterType = Annotated[
     Optional[str],
     Query(
         alias="filter",
-        description="""A CQL filter expression for filtering items.\n
-Supports `CQL-JSON` as defined in https://portal.ogc.org/files/96288\n
-Remember to URL encode the CQL-JSON if using GET""",
+        description="""A CQL2 filter expression for filtering items.\n
+Supports `CQL2` as defined in https://docs.ogc.org/is/21-065r2/21-065r2.html""",
         json_schema_extra={
             "example": "id='LC08_L1TP_060247_20180905_20180912_01_T1_L1TP' AND collection='landsat8_l1tp'",
         },
@@ -93,7 +96,7 @@ FilterLangType = Annotated[
     Optional[FilterLang],
     Query(
         alias="filter-lang",
-        description="The CQL filter encoding that the 'filter' value uses.",
+        description="The CQL2 filter encoding that the 'filter' value uses.",
     ),
 ]
 SortByType = Annotated[Optional[str], Query(description="Sort by +/-fieldName (ascending/descending)")]
@@ -153,6 +156,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
     select_config: Callable = lambda: None
     stac_to_odata: Callable = lambda: None
     map_mission: Callable = lambda: None
+    temporal_mapping: dict[str, str] | None = None
 
     # Is the service adgs or cadip ?
     adgs: bool = False
@@ -300,10 +304,12 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
     ) -> dict[str, Any]:
         """Synchronized search."""
 
+        logger.debug(f"sync_search with params: {params}")
+
         #
         # Step 1: read input params
 
-        stac_params = {}
+        stac_params: dict[str, Any] = {}
 
         def format_dict(field: dict):
             """Used for error handling."""
@@ -445,7 +451,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
             """Use a recursive function to read all CQL filter levels"""
             if not filt:
                 return
-            op = filt.get("op")
+            op: str = filt.get("op")  # type: ignore
             args = filt.get("args", [])
 
             # Read a single property
@@ -459,44 +465,58 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                 read_property(prop, value)
                 return
 
+            # Read temporal operators
+            if op in temporal_operations:
+                temporal_query: str = temporal_op_query(op, args, self.temporal_mapping)
+                logger.debug(f"Temporal operator {op} with args {args} -> {temporal_query}")
+                stac_params[op] = temporal_query
+                return
+
             # Else we are reading several properties
             if op != "and":
                 raise log_http_exception(
                     status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    f"Invalid CQL2 filter, only '=' and 'and' operators are allowed: {format_dict(filt)}",
+                    f"Invalid CQL2 filter, only '=', 'and' and temporal operators are allowed: {format_dict(filt)}",
                 )
             for sub_filter in args:
                 read_cql(sub_filter)
 
         def read_query(query_arg: str | None):
-            """Used to read query parameter cql2-text filter.
-            filter=prop1 = prop2
-            """
+            """Used to read query parameter cql2-text filter."""
             if not query_arg:
                 return
             # If there are more filters defined and joined by AND keyword, process each one and update stac_params.
-            if "AND" in query_arg:  # only AND for now.
-                conditions = [c.strip() for c in query_arg.split("AND")]
+            if re.search(r"\bAND\b", query_arg, re.IGNORECASE):  # only AND for now.
+                conditions = [c.strip() for c in re.split(r"\bAND\b", query_arg, flags=re.IGNORECASE)]
                 for condition in conditions:
                     read_query(condition)
                 return
-            # Handle only '=' for now
-            op = "="
-            if op not in query_arg:
+            # Handle '='
+            if "=" in query_arg:
+                kv = query_arg.split("=")
+                # Extract prop and check if it's in the queryables.
+                if (prop := kv[0].strip()) not in allowed_properties:
+                    raise log_http_exception(
+                        status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        f"Invalid query filter property: {prop!r}, allowed properties are: {allowed_properties}",
+                    )
+                value = str(kv[1]).strip("'\"")
+                check_input_type(self.get_queryables(), prop, value)
+                # Update stac params
+                stac_params[prop] = value  # type: ignore
+            # Handle CQL2 temporal operators
+            elif match := re.search(
+                r"\b(" + "|".join(map(re.escape, temporal_operations.keys())) + r")\b",
+                query_arg,
+                re.IGNORECASE,
+            ):
+                op = match.group(1).lower()
+                logger.debug(f"Temporal operator detected: {op} -> {stac_params[op]}")
+            else:
                 raise log_http_exception(
                     status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    "Invalid query filter, only '=' operator is allowed",
+                    "Invalid query filter, only '=' and temporal operators are allowed",
                 )
-            # Extract prop and check if it's in the queryables.
-            if (prop := query_arg.split(op)[0].strip()) not in allowed_properties:
-                raise log_http_exception(
-                    status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    f"Invalid query filter property: {prop!r}, allowed properties are: {allowed_properties}",
-                )
-            value = str(query_arg.split(op)[1]).strip("'\"")
-            check_input_type(self.get_queryables(), prop, value)
-            # Update stac params
-            stac_params[prop] = value  # type: ignore
 
         read_cql(params.pop("filter", {}))
         read_query(self.request.query_params.get("filter"))
@@ -607,8 +627,8 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
 
     def process_collection(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         self,
-        collection_id,
-        stac_params,
+        collection_id: str,
+        stac_params: dict,
         return_values: list[Sequence[Item] | Exception],
     ):
         """Method used to process a collection and perform search."""
@@ -616,6 +636,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
         empty_selection = False
         # Convert search params from STAC keys to OData keys
         odata_params = self.stac_to_odata(stac_params)
+        logger.debug(f"STAC/OData parameters mapping: {stac_params} => {odata_params}")
         try:
             # Some OData search params are hardcoded in the collection configuration.
             collection = self.select_config(collection_id)
@@ -686,6 +707,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                 search_page = 1
 
             # Do the search for this collection
+            logger.debug(f"Searching with OData parameters {self.odata}")
             features = (self.process_search(collection, self.odata, search_limit, search_page)).features
 
             # If search return maximum number of elements, increase page and process next elements

--- a/services/common/rs_server_common/stac_cql2.py
+++ b/services/common/rs_server_common/stac_cql2.py
@@ -1,0 +1,128 @@
+# Copyright 2024 CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module to parse CQL2 filter expressions, adapted from pgstac.sql,
+see https://github.com/stac-utils/pgstac/blob/main/src/pgstac/pgstac.sql"""
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+
+from .utils.utils import strftime_millis
+
+temporal_operations = {
+    "t_before": "lh < rl",
+    "t_after": "ll > rh",
+    "t_meets": "lh = rl",
+    "t_metby": "ll = rh",
+    "t_overlaps": "ll < rl and rl < lh and lh < rh",
+    "t_overlappedby": "rl < ll and ll < rh and lh > rh",
+    "t_starts": "ll = rl and lh < rh",
+    "t_startedby": "ll = rl and lh > rh",
+    "t_during": "ll > rl and lh < rh",
+    "t_contains": "ll < rl and lh > rh",
+    "t_finishes": "ll > rl and lh = rh",
+    "t_finishedby": "ll < rl and lh = rh",
+    "t_equals": "ll = rl and lh = rh",
+    "t_disjoint": "not (ll <= rh and lh >= rl)",
+    "t_intersects": "ll <= rh and lh >= rl",
+}
+
+
+def parse_dtrange(  # noqa: C901 # pylint: disable=too-many-branches
+    _indate: str | dict | list,
+    relative_base: datetime | None = None,
+) -> tuple[datetime, datetime]:
+    """parse datetime range"""
+    if relative_base is None:
+        relative_base = datetime.now(timezone.utc)
+
+    if isinstance(_indate, str):
+        try:
+            _indate = json.loads(_indate)
+        except json.JSONDecodeError:
+            _indate = [_indate]
+
+    if isinstance(_indate, dict):
+        if "timestamp" in _indate:
+            timestrs = [_indate["timestamp"]]
+        elif "interval" in _indate:
+            timestrs = _indate["interval"] if isinstance(_indate["interval"], list) else [_indate["interval"]]
+        else:
+            timestrs = re.split(r"/", _indate.get("0", ""))
+    elif isinstance(_indate, list):
+        timestrs = _indate
+    else:
+        raise ValueError(f"Invalid input format: {_indate}")
+
+    if len(timestrs) == 1:
+        if timestrs[0].upper().startswith("P"):
+            delta = parse_interval(timestrs[0])
+            return (relative_base - delta, relative_base)
+        s = datetime.fromisoformat(timestrs[0])
+        return (s, s)
+
+    if len(timestrs) != 2:
+        raise ValueError(f"Timestamp cannot have more than 2 values: {timestrs}")
+
+    if timestrs[0] in ["..", ""]:
+        s = datetime.min
+        e = datetime.fromisoformat(timestrs[1])
+    elif timestrs[1] in ["..", ""]:
+        s = datetime.fromisoformat(timestrs[0])
+        e = datetime.max
+    elif timestrs[0].upper().startswith("P") and not timestrs[1].upper().startswith("P"):
+        e = datetime.fromisoformat(timestrs[1])
+        s = e - parse_interval(timestrs[0])
+    elif timestrs[1].upper().startswith("P") and not timestrs[0].upper().startswith("P"):
+        s = datetime.fromisoformat(timestrs[0])
+        e = s + parse_interval(timestrs[1])
+    else:
+        s = datetime.fromisoformat(timestrs[0])
+        e = datetime.fromisoformat(timestrs[1])
+
+    return (s, e)
+
+
+def parse_interval(interval: str) -> timedelta:
+    """parse interval"""
+    match = re.match(r"P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?", interval.upper())
+    if match:
+        days, hours, minutes, seconds = (int(v) if v else 0 for v in match.groups())
+        return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+    raise ValueError(f"Invalid interval format: {interval}")
+
+
+def temporal_op_query(op: str, args: list[dict], temporal_mapping: dict[str, str]) -> str:
+    """temporal operation query"""
+    if op.lower() not in temporal_operations:
+        raise ValueError(f"Invalid temporal operator: {op}")
+    if not temporal_mapping:
+        raise ValueError("Undefined temporal property mapping")
+
+    props: list[dict] = args[0]["interval"] if "interval" in args[0].keys() else [args[0]]
+    rrange = parse_dtrange(args[1])
+    outq = (
+        temporal_operations[op.lower()]
+        .replace("ll", temporal_mapping[props[0]["property"]])
+        .replace("lh", temporal_mapping[props[1 if len(props) > 1 else 0]["property"]])
+        .replace("rl", strftime_millis(rrange[0]))
+        .replace("rh", strftime_millis(rrange[1]))
+        .replace("<=", "lte")
+        .replace(">=", "gte")
+        .replace("=", "eq")
+        .replace("<", "lt")
+        .replace(">", "gt")
+    )
+    return f"({outq})"

--- a/services/common/rs_server_common/utils/utils.py
+++ b/services/common/rs_server_common/utils/utils.py
@@ -224,3 +224,8 @@ def validate_sort_input(sortby: str):
     """
     sortby = sortby.strip("'\"").lower().replace("properties.", "")
     return [(sortby[1:] if sortby[0] in ["-", "+"] else sortby, "DESC" if sortby[0] == "-" else "ASC")]
+
+
+def strftime_millis(date: datetime):
+    """Format datetime with milliseconds precision"""
+    return date.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"

--- a/tests/resources/endpoints/adgs_search.yaml
+++ b/tests/resources/endpoints/adgs_search.yaml
@@ -216,7 +216,7 @@ collections:
     query: null
     stac_extensions: [ "https://stac-extensions.github.io/eo/v1.0.0/schema.json", "https://stac-extensions.github.io/projection/v1.0.0/schema.json", "https://stac-extensions.github.io/view/v1.0.0/schema.json" ]
     title: 'Test collection'
-    description: 'Sentinel-1 test CADIP sessions'
+    description: 'Auxiliary files from ADGS'
     license: other
     extent:
       spatial:
@@ -242,3 +242,14 @@ collections:
     station: adgs2
     query:
       limit: 100
+    description: 'Auxiliary files from ADGS2'
+    license: other
+    extent:
+      spatial:
+        bbox: [[ -180, -82.85, 180, 82.82 ]]
+      temporal:
+        interval: [[ '2024-06-12T02:57:21.459000Z', '2024-08-22T11:30:12.767000Z' ]]
+    links:
+      - rel: license
+        href: 'https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf'
+        title: 'Legal notice on the use of Copernicus Sentinel Data and Service Information'

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -1117,6 +1117,190 @@ class TestFeatureCollectionOdataStacMapping:
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
+        "fastapi_app, endpoint, odata, expected_code",
+        [
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_BEFORE(start_datetime, '2025-04-01T00:00:00Z')"
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start lt 2025-04-01T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_AFTER(start_datetime, '2025-04-01T00:00:00Z')"
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start gt 2025-04-01T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_MEETS(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/End eq 2025-04-01T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_METBY(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start eq 2025-04-02T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_OVERLAPS(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start lt 2025-04-01T00:00:00.000Z and 2025-04-01T00:00:00.000Z lt ContentDate/End and ContentDate/End lt 2025-04-02T00:00:00.000Z)"  # noqa: E501 # pylint: disable=line-too-long
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_OVERLAPPEDBY(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(2025-04-01T00:00:00.000Z lt ContentDate/Start and ContentDate/Start lt 2025-04-02T00:00:00.000Z and ContentDate/End gt 2025-04-02T00:00:00.000Z)"  # noqa: E501 # pylint: disable=line-too-long
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            # TODO enable these tests when pygeofilter supports these operators
+            # (
+            #    ROUTER_PREFIX_AUXIP,
+            #    "/auxip/search?collections=adgs&filter="
+            #    "T_STARTS(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+            #    "&sortby=-properties.created&limit=1",
+            #    "http://127.0.0.1:5000/Products?$filter="
+            #    "(ContentDate/Start eq 2025-04-01T00:00:00.000Z and ContentDate/End lt 2025-04-02T00:00:00.000Z)"
+            #    "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+            #    status.HTTP_200_OK,
+            # ),
+            # (
+            #    ROUTER_PREFIX_AUXIP,
+            #    "/auxip/search?collections=adgs&filter="
+            #    "T_STARTEDBY(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+            #    "&sortby=-properties.created&limit=1",
+            #    "http://127.0.0.1:5000/Products?$filter="
+            #    "(ContentDate/Start eq 2025-04-01T00:00:00.000Z and ContentDate/End gt 2025-04-02T00:00:00.000Z)"
+            #    "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+            #    status.HTTP_200_OK,
+            # ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_DURING(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start gt 2025-04-01T00:00:00.000Z and ContentDate/End lt 2025-04-02T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_CONTAINS(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start lt 2025-04-01T00:00:00.000Z and ContentDate/End gt 2025-04-02T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            # TODO enable these tests when pygeofilter supports these operators
+            # (
+            #    ROUTER_PREFIX_AUXIP,
+            #    "/auxip/search?collections=adgs&filter="
+            #    "T_FINISHES(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+            #    "&sortby=-properties.created&limit=1",
+            #    "http://127.0.0.1:5000/Products?$filter="
+            #    "(ContentDate/Start gt 2025-04-01T00:00:00.000Z and ContentDate/End eq 2025-04-02T00:00:00.000Z)"
+            #    "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+            #    status.HTTP_200_OK,
+            # ),
+            # (
+            #    ROUTER_PREFIX_AUXIP,
+            #    "/auxip/search?collections=adgs&filter="
+            #    "T_FINISHEDBY(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+            #    "&sortby=-properties.created&limit=1",
+            #    "http://127.0.0.1:5000/Products?$filter="
+            #    "(ContentDate/Start lt 2025-04-01T00:00:00.000Z and ContentDate/End eq 2025-04-02T00:00:00.000Z)"
+            #    "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+            #    status.HTTP_200_OK,
+            # ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_EQUALS(INTERVAL(start_datetime, end_datetime), INTERVAL('2025-04-01T00:00:00Z', '2025-04-02T00:00:00Z'))"  # noqa: E501 # pylint: disable=line-too-long
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start eq 2025-04-01T00:00:00.000Z and ContentDate/End eq 2025-04-02T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+            # TODO enable these tests when pygeofilter supports these operators
+            # (
+            #    ROUTER_PREFIX_AUXIP,
+            #    "/auxip/search?collections=adgs&filter="
+            #    "T_DISJOINT(start_datetime, '2025-04-01T00:00:00Z')"
+            #    "&sortby=-properties.created&limit=1",
+            #    "http://127.0.0.1:5000/Products?$filter="
+            #    "not (ContentDate/Start lte 2025-04-02T00:00:00.000Z and ContentDate/End gte 2025-04-01T00:00:00.000Z)"
+            #    "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+            #    status.HTTP_200_OK,
+            # ),
+            (
+                ROUTER_PREFIX_AUXIP,
+                "/auxip/search?collections=adgs&filter="
+                "T_INTERSECTS(start_datetime, '2025-04-01T00:00:00Z')"
+                "&sortby=-properties.created&limit=1",
+                "http://127.0.0.1:5000/Products?$filter="
+                "(ContentDate/Start lte 2025-04-01T00:00:00.000Z and ContentDate/Start gte 2025-04-01T00:00:00.000Z)"
+                "&$orderby=PublicationDate desc&$top=1&$skip=0&$expand=Attributes",
+                status.HTTP_200_OK,
+            ),
+        ],
+        indirect=["fastapi_app"],
+        ids=[
+            "t_before",
+            "t_after",
+            "t_meets",
+            "t_metby",
+            "t_overlaps",
+            "t_overlappedby",
+            # "t_starts",
+            # "t_startedby",
+            "t_during",
+            "t_contains",
+            # "t_finishes",
+            # "t_finishedby",
+            "t_equals",
+            # "t_disjoint",
+            "t_intersects",
+        ],
+    )
+    @responses.activate
+    def test_temporal_operators(self, client, endpoint, odata, expected_code):
+        """Test used to group tests au temporal operators used to retrieve auxiliary data with DPR CQL2 filters."""
+        responses.add(responses.GET, odata, json={"value": []}, status=200)
+        response = client.get(endpoint)
+        assert response.status_code == expected_code
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
         "endpoint, page, is_last",
         [
             ("/auxip/collections/s2_adgs2_AUX_OBMEMC/items?token=next:page=", "3", True),


### PR DESCRIPTION
https://github.com/RS-PYTHON/rs-server/pull/1156
https://github.com/RS-PYTHON/rs-helm/pull/125
https://github.com/RS-PYTHON/rs-demo/pull/137

Add support for these CQL2 temporal operators:

```
            - "{t_before}"
            - "{t_after}"
            - "{t_meets}"
            - "{t_metby}"
            - "{t_overlaps}"
            - "{t_overlappedby}"
            - "{t_starts}"
            - "{t_startedby}"
            - "{t_during}"
            - "{t_contains}"
            - "{t_finishes}"
            - "{t_finishedby}"
            - "{t_equals}"
            - "{t_disjoint}"
            - "{t_intersects}"
```

Unfortunately pygeofilter does not support these operators:

```
    T_STARTS/T_STARTEDBY
    T_FINISHES/T_FINISHEDBY
    T_DISJOINT
```

See https://github.com/geopython/pygeofilter/issues/120