### PR TITLE
RSPY-611 - update all STAC extensions to the new domain

### DIFF
--- a/services/adgs/config/ODataToSTAC_template.json
+++ b/services/adgs/config/ODataToSTAC_template.json
@@ -1,7 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": [
-        "https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json",
+        "https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],

--- a/services/adgs/config/adgs_search_config.template.yaml
+++ b/services/adgs/config/adgs_search_config.template.yaml
@@ -18,7 +18,7 @@ template:
   query:
   stac_extensions:
     [
-      "https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json",
+      "https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json",
       "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
       "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json",

--- a/services/adgs/config/adgs_search_config.yaml
+++ b/services/adgs/config/adgs_search_config.yaml
@@ -22,7 +22,7 @@ collections:
   station: adgs
   query: null
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -63,7 +63,7 @@ collections:
   station: adgs2
   query: null
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -105,7 +105,7 @@ collections:
   query:
     productType: AUX_PP2
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -147,7 +147,7 @@ collections:
   query:
     productType: OPER_AUX_ECMWFD_PDMC
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -189,7 +189,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -231,7 +231,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC_PDMC
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -273,7 +273,7 @@ collections:
   query:
     productType: OPER_AUX_PREORB_OPOD
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -315,7 +315,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPOD
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -357,7 +357,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPODs
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -399,7 +399,7 @@ collections:
   query:
     productType: OPER_MPL_ORBPRE
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -441,7 +441,7 @@ collections:
   query:
     productType: OPER_MPL_ORBSCT
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -483,7 +483,7 @@ collections:
   query:
     productType: AUX_PP2
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -525,7 +525,7 @@ collections:
   query:
     productType: OPER_AUX_ECMWFD_PDMC
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -567,7 +567,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -609,7 +609,7 @@ collections:
   query:
     productType: OPER_AUX_OBMEMC_PDMC
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -651,7 +651,7 @@ collections:
   query:
     productType: OPER_AUX_PREORB_OPOD
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -693,7 +693,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPOD
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -735,7 +735,7 @@ collections:
   query:
     productType: OPER_AUX_RESORB_OPODs
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -777,7 +777,7 @@ collections:
   query:
     productType: OPER_MPL_ORBPRE
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -819,7 +819,7 @@ collections:
   query:
     productType: OPER_MPL_ORBSCT
   stac_extensions:
-  - https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json

--- a/services/cadip/config/ODataToSTAC_template.json
+++ b/services/cadip/config/ODataToSTAC_template.json
@@ -1,7 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": [
-        "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
+        "https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json"
     ],
     "type": "Feature",

--- a/services/cadip/config/cadip_search_config.template.yaml
+++ b/services/cadip/config/cadip_search_config.template.yaml
@@ -18,7 +18,7 @@ template:
   query:
   stac_extensions:
     [
-      "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
+      "https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json",
       "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
       "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json",

--- a/services/cadip/config/cadip_search_config.yaml
+++ b/services/cadip/config/cadip_search_config.yaml
@@ -22,7 +22,7 @@ collections:
   station: cadip
   query: null
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -63,7 +63,7 @@ collections:
   station: mti
   query: null
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -104,7 +104,7 @@ collections:
   station: sgs
   query: null
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -146,7 +146,7 @@ collections:
   query:
     Satellite: S1A, S1B, S1C
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -188,7 +188,7 @@ collections:
   query:
     Satellite: S2A, S2B, S2C
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -230,7 +230,7 @@ collections:
   query:
     Satellite: S3A, S3B
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -272,7 +272,7 @@ collections:
   query:
     Satellite: S5P
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -314,7 +314,7 @@ collections:
   query:
     Satellite: S1A, S1B, S1C
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -356,7 +356,7 @@ collections:
   query:
     Satellite: S2A, S2B, S2C
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -398,7 +398,7 @@ collections:
   query:
     Satellite: S3A, S3B
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -440,7 +440,7 @@ collections:
   query:
     Satellite: S5P
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -482,7 +482,7 @@ collections:
   query:
     Satellite: S1A, S1B, S1C
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -524,7 +524,7 @@ collections:
   query:
     Satellite: S2A, S2B, S2C
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -566,7 +566,7 @@ collections:
   query:
     Satellite: S3A, S3B
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json
@@ -608,7 +608,7 @@ collections:
   query:
     Satellite: S5P
   stac_extensions:
-  - https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json
+  - https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json
   - https://stac-extensions.github.io/eo/v1.0.0/schema.json
   - https://stac-extensions.github.io/projection/v1.0.0/schema.json
   - https://stac-extensions.github.io/view/v1.0.0/schema.json

--- a/services/cadip/config/cadip_session_ODataToSTAC_template.json
+++ b/services/cadip/config/cadip_session_ODataToSTAC_template.json
@@ -1,7 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": [
-        "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
+        "https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],

--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -431,7 +431,7 @@ collections/{user}:{collection_id}/items/{self.request_ids['item_id']}/download/
 
         # 3 - include new stac extensions if not present
         for new_stac_extension in [
-            "https://rs-python.github.io/ownership-stac-extension/v1.0.0/schema.json",
+            "https://home.rs-python.eu/ownership-stac-extension/v1.1.0/schema.json",
             "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
         ]:
             if new_stac_extension not in content["stac_extensions"]:

--- a/tests/resources/endpoints/adgs_feature.json
+++ b/tests/resources/endpoints/adgs_feature.json
@@ -48,7 +48,7 @@
         }
     ],
     "stac_extensions": [
-        "https://rs-python.github.io/auxip-stac-extension/v1.0.0/schema.json",
+        "https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],

--- a/tests/resources/endpoints/cadip_feature.json
+++ b/tests/resources/endpoints/cadip_feature.json
@@ -80,7 +80,7 @@
         }
     ],
     "stac_extensions": [
-        "https://rs-python.github.io/cadip-stac-extension/v1.0.0/schema.json",
+        "https://home.rs-python.eu/cadip-stac-extension/v1.1.0/schema.json",
         "https://stac-extensions.github.io/file/v2.1.0/schema.json",
         "https://stac-extensions.github.io/timestamps/v1.1.0/schema.json"
     ],


### PR DESCRIPTION
Required for CORS compatibility with stac-browser

https://github.com/RS-PYTHON/rs-server/pull/1162
https://github.com/RS-PYTHON/rs-helm/pull/113