### PR TITLE
RSPY-662: include 'id' in AUXIP queryables

### DIFF
--- a/services/common/config/adgs_queryables.yaml
+++ b/services/common/config/adgs_queryables.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+id:
+  type: string
+  title: id
+  format: string
+  description: string
 platform:
   type: string
   title: platform


### PR DESCRIPTION
Fix to allow this kind of requests:

https://rspy.ops.rs-python.eu/auxip/search?collections=S1-MPL_ORBPRE&limit=1&filter=id=S1A_OPER_MPL_ORBPRE_20250412T021831_20250419T021830_0001.EOF.zip