### PR TITLE
Fix logging issue in sync script

### DIFF
--- a/resources/sync_config_files.py
+++ b/resources/sync_config_files.py
@@ -20,6 +20,7 @@ Copy them to rs-demo, rs-helm and rs-server-deployment repositories.
 import collections.abc
 import copy
 import json
+import logging
 import numbers
 import os
 import re
@@ -30,13 +31,12 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from rs_server_common.utils.logging import Logging
 from yaml.representer import SafeRepresenter
 
 # Avoid yaml references, see: https://stackoverflow.com/a/30682604
 yaml.Dumper.ignore_aliases = lambda *_: True  # type: ignore
 
-logger = Logging.default(Path(__file__).name)
+logger = logging.getLogger(__name__)
 
 #
 # Class definition
@@ -541,8 +541,10 @@ def copy_to_helm_or_infra_single_doc(  # pylint: disable=too-many-statements
             output_config: current output yaml block
             station: is the current yaml block implementing an adgs station, or cadip station, or ...
         """
-        if not isinstance(input_config, dict) or not isinstance(output_config, dict):
-            raise RuntimeError(f"Invalid arguments: {input_config} / {output_config}")
+        if not isinstance(input_config, dict):
+            raise RuntimeError(f"Invalid input_config: {input_config}")
+        if not isinstance(output_config, dict):
+            raise RuntimeError(f"Invalid output_config: {output_config}")
 
         # Check station name from parent key
         station = copy.deepcopy(station)  # save the instance so the previous recursive calls are not impacted


### PR DESCRIPTION
Fixes an error with the new log format, but there is still an error to fix:

```
$ python resources/sync_config_files.py 

Missing from rs-server: 'adgs.trusteddomains'
Traceback (most recent call last):
  File "/home/vprivat/projects/rspy/rs-server/resources/sync_config_files.py", line 696, in <module>
    copy_to_helm_or_infra([station_params], rs_deploy_dir / "apps/01-rs-server-station-secrets/values.yaml")
  File "/home/vprivat/projects/rspy/rs-server/resources/sync_config_files.py", line 408, in copy_to_helm_or_infra
    copy_to_helm_or_infra_single_doc(params, output_configs[params.output_doc_index])
  File "/home/vprivat/projects/rspy/rs-server/resources/sync_config_files.py", line 642, in copy_to_helm_or_infra_single_doc
    update_all_values([], input_config, output_config)
  File "/home/vprivat/projects/rspy/rs-server/resources/sync_config_files.py", line 547, in update_all_values
    raise RuntimeError(f"Invalid output_config: {output_config}")
RuntimeError: Invalid output_config: DOUBLE_CURLY_BRACES_OPEN rs_server_station_secrets.stations | indent( width=4, first=False) DOUBLE_CURLY_BRACES_CLOSE
```