### PR TITLE
RSPY-706 - STAC search: avoid spamming stations with many collections

### DIFF
--- a/resources/sync_config_files.py
+++ b/resources/sync_config_files.py
@@ -405,7 +405,10 @@ def copy_to_helm_or_infra(
             raise RuntimeError(f"Document index #{params.output_doc_index} not found in: {output_path!r}")
 
         # Call the sub-function on a single doc
-        copy_to_helm_or_infra_single_doc(params, output_configs[params.output_doc_index])
+        try:
+            copy_to_helm_or_infra_single_doc(params, output_configs[params.output_doc_index])
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error(f"Failed to update single infra doc: {params}", e)
 
     # Get the file header from the list of input configuration files
     input_paths = {rs_server_dir / param.input_path_relative for param in all_params}
@@ -639,7 +642,10 @@ def copy_to_helm_or_infra_single_doc(  # pylint: disable=too-many-statements
                         elif isinstance(output_subvalue, numbers.Number):
                             output_value[i] = input_subvalue
 
-    update_all_values([], input_config, output_config)
+    if isinstance(input_config, dict) and isinstance(output_config, dict):
+        update_all_values([], input_config, output_config)
+    else:
+        logger.error(f"Cannot update values for {input_config} => {output_config}")
 
     # Call post-processing on output configuration
     if params.post_processing:

--- a/services/adgs/config/adgs_ws_config.template.yaml
+++ b/services/adgs/config/adgs_ws_config.template.yaml
@@ -89,10 +89,19 @@ template:
       attr_ptype:
         - null
         - "$.attr_ptype"
+      attr_ptypes:
+        - null
+        - "$.attr_ptype"
       platformSerialIdentifier:
         - null
         - "$.platformSerialIdentifier"
+      platformSerialIdentifiers:
+        - null
+        - "$.platformSerialIdentifier"
       platformShortName:
+        - null
+        - "$.platformShortName"
+      platformShortNames:
         - null
         - "$.platformShortName"
       processing:datetime:
@@ -120,9 +129,12 @@ template:
             - "(PublicationDate gt {StartPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StartPublicationDate#to_iso_utc_datetime})"
             - "(PublicationDate lt {StopPublicationDate#to_iso_utc_datetime} or PublicationDate eq {StopPublicationDate#to_iso_utc_datetime})"
             - "PublicationDate eq {PublicationDate#to_iso_utc_datetime}"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value eq '{attr_ptype}')"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier' and att/OData.CSC.StringAttribute/Value eq '{platformSerialIdentifier}')"
-            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName' and att/OData.CSC.StringAttribute/Value eq '{platformShortName#to_upper}')"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value eq {attr_ptype})"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and att/OData.CSC.StringAttribute/Value in ({attr_ptypes}))"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier' and att/OData.CSC.StringAttribute/Value eq {platformSerialIdentifier})"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier' and att/OData.CSC.StringAttribute/Value in ({platformSerialIdentifiers}))"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName' and att/OData.CSC.StringAttribute/Value eq {platformShortName#to_upper})"
+            - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName' and att/OData.CSC.StringAttribute/Value in ({platformShortNames#to_upper}))"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'processingDate' and att/OData.CSC.StringAttribute/Value eq '{processing:datetime#to_iso_utc_datetime}')"
             - "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'processingCenter' and att/OData.CSC.StringAttribute/Value eq '{processingCenter#to_iso_utc_datetime}')"
             - "ContentDate/Start gt {Start#to_iso_utc_datetime}"

--- a/services/adgs/config/adgs_ws_config.yaml
+++ b/services/adgs/config/adgs_ws_config.yaml
@@ -90,10 +90,19 @@ adgs:
       attr_ptype:
       - null
       - $.attr_ptype
+      attr_ptypes:
+      - null
+      - $.attr_ptype
       platformSerialIdentifier:
       - null
       - $.platformSerialIdentifier
+      platformSerialIdentifiers:
+      - null
+      - $.platformSerialIdentifier
       platformShortName:
+      - null
+      - $.platformShortName
+      platformShortNames:
       - null
       - $.platformShortName
       processing:datetime:
@@ -125,11 +134,17 @@ adgs:
             eq {StopPublicationDate#to_iso_utc_datetime})
           - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType'
-            and att/OData.CSC.StringAttribute/Value eq '{attr_ptype}')
+            and att/OData.CSC.StringAttribute/Value eq {attr_ptype})
+          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType'
+            and att/OData.CSC.StringAttribute/Value in ({attr_ptypes}))
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier'
-            and att/OData.CSC.StringAttribute/Value eq '{platformSerialIdentifier}')
+            and att/OData.CSC.StringAttribute/Value eq {platformSerialIdentifier})
+          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier'
+            and att/OData.CSC.StringAttribute/Value in ({platformSerialIdentifiers}))
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName'
-            and att/OData.CSC.StringAttribute/Value eq '{platformShortName#to_upper}')
+            and att/OData.CSC.StringAttribute/Value eq {platformShortName#to_upper})
+          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName'
+            and att/OData.CSC.StringAttribute/Value in ({platformShortNames#to_upper}))
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'processingDate'
             and att/OData.CSC.StringAttribute/Value eq '{processing:datetime#to_iso_utc_datetime}')
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'processingCenter'
@@ -250,10 +265,19 @@ adgs2:
       attr_ptype:
       - null
       - $.attr_ptype
+      attr_ptypes:
+      - null
+      - $.attr_ptype
       platformSerialIdentifier:
       - null
       - $.platformSerialIdentifier
+      platformSerialIdentifiers:
+      - null
+      - $.platformSerialIdentifier
       platformShortName:
+      - null
+      - $.platformShortName
+      platformShortNames:
       - null
       - $.platformShortName
       processing:datetime:
@@ -285,11 +309,17 @@ adgs2:
             eq {StopPublicationDate#to_iso_utc_datetime})
           - PublicationDate eq {PublicationDate#to_iso_utc_datetime}
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType'
-            and att/OData.CSC.StringAttribute/Value eq '{attr_ptype}')
+            and att/OData.CSC.StringAttribute/Value eq {attr_ptype})
+          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType'
+            and att/OData.CSC.StringAttribute/Value in ({attr_ptypes}))
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier'
-            and att/OData.CSC.StringAttribute/Value eq '{platformSerialIdentifier}')
+            and att/OData.CSC.StringAttribute/Value eq {platformSerialIdentifier})
+          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformSerialIdentifier'
+            and att/OData.CSC.StringAttribute/Value in ({platformSerialIdentifiers}))
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName'
-            and att/OData.CSC.StringAttribute/Value eq '{platformShortName#to_upper}')
+            and att/OData.CSC.StringAttribute/Value eq {platformShortName#to_upper})
+          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName'
+            and att/OData.CSC.StringAttribute/Value in ({platformShortNames#to_upper}))
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'processingDate'
             and att/OData.CSC.StringAttribute/Value eq '{processing:datetime#to_iso_utc_datetime}')
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'processingCenter'

--- a/services/adgs/rs_server_adgs/adgs_retriever.py
+++ b/services/adgs/rs_server_adgs/adgs_retriever.py
@@ -65,4 +65,4 @@ def init_adgs_provider(station: str) -> EodagProvider:
         return EodagProvider(ext_auth_config, eodag_config, station)
 
     except Exception as exception:
-        raise CreateProviderFailed("Failed to setup eodag") from exception
+        raise CreateProviderFailed(f"Failed to setup eodag for AUXIP station {station}") from exception

--- a/services/adgs/rs_server_adgs/adgs_utils.py
+++ b/services/adgs/rs_server_adgs/adgs_utils.py
@@ -41,6 +41,22 @@ def read_conf():
     return config  # WARNING: if the caller wants to modify this cached object, it must deepcopy it first
 
 
+@lru_cache
+def auxip_odata_to_stac_template():
+    """Used each time to read the ODataToSTAC_template json template."""
+    with open(ADGS_CONFIG / "ODataToSTAC_template.json", encoding="utf-8") as mapper:
+        config = json.loads(mapper.read())
+    return config  # WARNING: if the caller wants to modify this cached object, he must deepcopy it first
+
+
+@lru_cache
+def auxip_stac_mapper():
+    """Used each time to read the adgs_stac_mapper config yaml."""
+    with open(ADGS_CONFIG / "adgs_stac_mapper.json", encoding="utf-8") as stac_map:
+        config = json.loads(stac_map.read())
+    return config  # WARNING: if the caller wants to modify this cached object, it must deepcopy it first
+
+
 def select_config(configuration_id: str) -> dict | None:
     """Used to select a specific configuration from yaml file, returns None if not found."""
     return next(
@@ -51,14 +67,11 @@ def select_config(configuration_id: str) -> dict | None:
 
 def stac_to_odata(stac_params: dict) -> dict:
     """Convert a parameter directory from STAC keys to OData keys. Return the new directory."""
-    stac_mapper_path = ADGS_CONFIG / "adgs_stac_mapper.json"
-    with open(stac_mapper_path, encoding="utf-8") as stac_map:
-        stac_mapper = json.loads(stac_map.read())
-        return {stac_mapper.get(stac_key, stac_key): value for stac_key, value in stac_params.items()}
+    return {auxip_stac_mapper().get(stac_key, stac_key): value for stac_key, value in stac_params.items()}
 
 
 def serialize_adgs_asset(feature_collection, products):
-    """Used to update adgs asset with propper href and format {asset_name: asset_body}."""
+    """Used to update adgs asset with proper href and format {asset_name: asset_body}."""
     for feature in feature_collection.features:
         auxip_id = feature.properties.dict()["auxip:id"]
         # Find matching product by id and update feature href
@@ -75,12 +88,12 @@ def serialize_adgs_asset(feature_collection, products):
 
 
 def get_adgs_queryables() -> dict[str, QueryableField]:
-    """Function to list all available queryables for ADGS session search."""
+    """Function to list all available queryables for ADGS file search."""
     return {
         "PublicationDate": QueryableField(
             title="PublicationDate",
             type="Interval",
-            description="Session Publication Date",
+            description="File Publication Date",
             format="1940-03-10T12:00:00Z/2024-01-01T12:00:00Z",
         ),
         "processingDate": QueryableField(
@@ -110,7 +123,7 @@ def get_adgs_queryables() -> dict[str, QueryableField]:
     }
 
 
-def auxip_map_mission(platform: str, constellation: str):
+def auxip_map_mission(platform: str, constellation: str) -> tuple[str | None, str | None]:
     """
     Custom function for ADGS, to read constellation mapper and return propper
     values for platform and serial.

--- a/services/adgs/rs_server_adgs/adgs_utils.py
+++ b/services/adgs/rs_server_adgs/adgs_utils.py
@@ -172,7 +172,8 @@ def adgs_reverse_map_mission(
     if not (constellation or platform):
         return None, None
 
-    constellation = constellation.lower()  # type: ignore
+    if constellation:
+        constellation = constellation.lower()  # type: ignore
 
     for satellite in map_stac_platform()["satellites"]:
         for key, info in satellite.items():

--- a/services/adgs/rs_server_adgs/api/adgs_search.py
+++ b/services/adgs/rs_server_adgs/api/adgs_search.py
@@ -18,9 +18,9 @@ This module provides functionality to retrieve a list of products from the ADGS 
 It includes an API endpoint, utility functions, and initialization for accessing EODataAccessGateway.
 """
 
-import json
 import os.path as osp
 import traceback
+from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -33,6 +33,8 @@ from fastapi.responses import RedirectResponse
 from rs_server_adgs import adgs_retriever, adgs_tags
 from rs_server_adgs.adgs_utils import (
     auxip_map_mission,
+    auxip_odata_to_stac_template,
+    auxip_stac_mapper,
     prepare_collection,
     read_conf,
     select_config,
@@ -96,24 +98,19 @@ class MockPgstacAdgs(MockPgstac):
     @handle_exceptions
     def process_search(
         self,
-        collection: dict,
+        station: str,
         odata_params: dict,
+        collection_provider: Callable[[dict], str | None],
         limit: int,
         page: int,
     ) -> stac_pydantic.ItemCollection:
-        """Search adgs products for the given collection and OData parameters."""
+        """Search adgs products for the given station and OData parameters."""
         # Update odata names that shadow eodag builtins (productype)
 
         odata_params["Name"] = names[0] if isinstance(names := odata_params.get("Name"), list) else names
         odata_params["attr_ptype"] = odata_params.pop("productType", None)
 
-        return process_product_search(
-            collection.get("station", "adgs"),
-            odata_params,
-            limit,
-            self.sortby,
-            page,
-        )
+        return process_product_search(station, odata_params, collection_provider, limit, self.sortby, page)
 
 
 def auth_validation(request: Request, collection_id: str, access_type: str):
@@ -319,10 +316,11 @@ async def get_adgs_collection_specific_item(
 
 
 def process_product_search(  # pylint: disable=too-many-locals
-    station,
-    queryables,
-    limit,
-    sortby,
+    station: str,
+    queryables: dict,
+    collection_provider: Callable[[dict], str | None],
+    limit: int,
+    sortby: str,
     page: int = 1,
     **kwargs,
 ) -> stac_pydantic.ItemCollection:
@@ -332,6 +330,8 @@ def process_product_search(  # pylint: disable=too-many-locals
     Args:
         station (str): Auxip station identifier.
         queryables (dict): Query parameters for filtering results.
+        collection_provider (Callable[[dict], str | None]): Function that determines STAC collection
+                                                            for a given OData entity
         limit (int): Maximum number of products to return.
         sortby (str): Sorting field with +/- prefix for ascending/descending order.
         page (int, optional): Page number for pagination. Defaults to 1.
@@ -354,16 +354,13 @@ def process_product_search(  # pylint: disable=too-many-locals
             page=page,
             **kwargs,
         )
-        feature_template_path = ADGS_CONFIG / "ODataToSTAC_template.json"
-        stac_mapper_path = ADGS_CONFIG / "adgs_stac_mapper.json"
-        with (
-            open(feature_template_path, encoding="utf-8") as template,
-            open(stac_mapper_path, encoding="utf-8") as stac_map,
-        ):
-            feature_template = json.loads(template.read())
-            stac_mapper = json.loads(stac_map.read())
-            collection = create_stac_collection(products, feature_template, stac_mapper)
-            return prepare_collection(serialize_adgs_asset(collection, products))
+        collection = create_stac_collection(
+            products,
+            auxip_odata_to_stac_template(),
+            auxip_stac_mapper(),
+            collection_provider,
+        )
+        return prepare_collection(serialize_adgs_asset(collection, products))
     # pylint: disable=duplicate-code
     except CreateProviderFailed as exception:
         logger.error(f"Failed to create EODAG provider!\n{traceback.format_exc()}")
@@ -377,7 +374,6 @@ def process_product_search(  # pylint: disable=too-many-locals
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=f"Station ADGS connection error: {exception}",
         ) from exception
-
     except Exception as exception:  # pylint: disable=broad-exception-caught
         logger.error(f"General failure! {exception}")
         if isinstance(exception, HTTPException):

--- a/services/adgs/rs_server_adgs/api/adgs_search.py
+++ b/services/adgs/rs_server_adgs/api/adgs_search.py
@@ -56,6 +56,7 @@ from rs_server_common.stac_api_common import (
     check_bbox_input,
     create_stac_collection,
     handle_exceptions,
+    split_multiple_values,
 )
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils import validate_inputs_format, validate_sort_input
@@ -108,7 +109,12 @@ class MockPgstacAdgs(MockPgstac):
         # Update odata names that shadow eodag builtins (productype)
 
         odata_params["Name"] = names[0] if isinstance(names := odata_params.get("Name"), list) else names
-        odata_params["attr_ptype"] = odata_params.pop("productType", None)
+        if product_type := odata_params.pop("productType", None):
+            odata_params["attr_ptype"] = split_multiple_values(product_type)
+
+        for key in ("platformSerialIdentifier", "platformShortName"):
+            if value := odata_params.pop(key, None):
+                odata_params[key] = split_multiple_values(value)
 
         return process_product_search(station, odata_params, collection_provider, limit, self.sortby, page)
 

--- a/services/cadip/config/cadip_ws_config.yaml
+++ b/services/cadip/config/cadip_ws_config.yaml
@@ -733,7 +733,7 @@ cadip_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -919,7 +919,7 @@ ins_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1105,7 +1105,7 @@ mps_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1291,7 +1291,7 @@ mti_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1477,7 +1477,7 @@ nsg_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1663,7 +1663,7 @@ sgs_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId

--- a/services/cadip/config/cadip_ws_config_token_module.yaml
+++ b/services/cadip/config/cadip_ws_config_token_module.yaml
@@ -730,7 +730,7 @@ cadip_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -900,7 +900,7 @@ ins_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1070,7 +1070,7 @@ mps_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1240,7 +1240,7 @@ mti_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1410,7 +1410,7 @@ nsg_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId
@@ -1580,7 +1580,7 @@ sgs_session:
       - $.DownlinkOrbit
       AcquisitionId:
       - null
-      - "$.AcquisitionId"
+      - $.AcquisitionId
       AntennaId:
       - null
       - $.AntennaId

--- a/services/cadip/rs_server_cadip/api/cadip_search.py
+++ b/services/cadip/rs_server_cadip/api/cadip_search.py
@@ -18,12 +18,12 @@ This module provides functionality to retrieve a list of products from the CADU 
 It includes an API endpoint, utility functions, and initialization for accessing EODataAccessGateway.
 """
 
-import json
 import threading
 import traceback
 
 # pylint: disable=redefined-builtin
 from collections import defaultdict
+from collections.abc import Callable
 from typing import Annotated, Literal
 
 import requests
@@ -37,8 +37,10 @@ from fastapi.responses import RedirectResponse
 from pydantic import validate_call
 from rs_server_cadip import cadip_retriever, cadip_tags
 from rs_server_cadip.cadip_utils import (
-    CADIP_CONFIG,
     cadip_map_mission,
+    cadip_odata_to_stac_template,
+    cadip_session_odata_to_stac_template,
+    cadip_session_stac_mapper,
     cadip_stac_mapper,
     link_assets_to_session,
     prepare_collection,
@@ -66,6 +68,7 @@ from rs_server_common.stac_api_common import (
 )
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils import (
+    run_threads,
     validate_inputs_format,
     validate_sort_input,
     validate_str_list,
@@ -115,20 +118,14 @@ class MockPgstacCadip(MockPgstac):
     @handle_exceptions
     def process_search(  # type: ignore
         self,
-        collection: dict,
+        station: str,
         odata_params: dict,
+        collection_provider: Callable[[dict], str | None],
         limit: int,
         page: int,
     ) -> stac_pydantic.ItemCollection:
-        """Search cadip sessions the given collection and OData parameters."""
-        return process_session_search(
-            self.request,
-            collection.get("station", "cadip"),
-            odata_params,
-            self.sortby,
-            limit,
-            page,
-        )
+        """Search cadip sessions for the given station and OData parameters."""
+        return process_session_search(station, odata_params, collection_provider, self.sortby, limit, page)
 
     @handle_exceptions
     def process_asset_search(
@@ -189,20 +186,19 @@ class MockPgstacCadip(MockPgstac):
             grouped_sessions[session.collection].append(session)
 
         # Update input session assets with their associated files, in separate threads
-        file_threads = [
-            threading.Thread(
-                target=self.process_asset_search,
-                args=(
-                    self.select_config(collection_id)["station"],
-                    session_features,
-                ),
-            )
-            for collection_id, session_features in grouped_sessions.items()
-        ]
-        for thread in file_threads:
-            thread.start()
-        for thread in file_threads:
-            thread.join()
+        run_threads(
+            [
+                threading.Thread(
+                    target=self.process_asset_search,
+                    args=(
+                        self.select_config(collection_id)["station"],
+                        session_features,
+                    ),
+                )
+                for collection_id, session_features in grouped_sessions.items()
+                if collection_id
+            ],
+        )
 
         # Convert back the stac object into dict.
         # We implemented some custom Item formating, so we do a back and forth conversion
@@ -470,9 +466,9 @@ async def get_cadip_collection_item_details(
 
 @validate_call(config={"arbitrary_types_allowed": True})
 def process_session_search(  # type: ignore # pylint: disable=too-many-arguments, too-many-locals, unused-argument
-    request: Request,
     station: str,
     queryables,
+    collection_provider: Callable[[dict], str | None],
     sortby: str,
     limit: Annotated[
         int | None,
@@ -486,9 +482,10 @@ def process_session_search(  # type: ignore # pylint: disable=too-many-arguments
     (*start_date* and *stop_date* correctly defined).
 
     Args:
-        request (Request): The request object (unused).
         station (str): CADIP station identifier (e.g., MTI, SGS, MPU, INU).
         queryables (dict): Lists of queryables applicable to search op.
+        collection_provider (Callable[[dict], str | None]): Function that determines STAC collection
+                                                            for a given OData entity
         limit (int, optional): Maximum number of products to return. Greater than 0, defaults to 100.
         sortby (str): Sort by +/-fieldName (ascending/descending).
         page (int): Page number to be displayed, defaults to first one.
@@ -542,23 +539,14 @@ def process_session_search(  # type: ignore # pylint: disable=too-many-arguments
             log_http_exception(logger, status.HTTP_500_INTERNAL_SERVER_ERROR, e)
 
         products = validate_products(products)
-        feature_template_path = CADIP_CONFIG / "cadip_session_ODataToSTAC_template.json"
-        stac_mapper_path = CADIP_CONFIG / "cadip_sessions_stac_mapper.json"
-        with (
-            open(feature_template_path, encoding="utf-8") as template,
-            open(stac_mapper_path, encoding="utf-8") as stac_map,
-        ):
-            feature_template = json.loads(template.read())
-            stac_mapper = json.loads(stac_map.read())
-            collection = create_stac_collection(products, feature_template, stac_mapper)
-            return prepare_collection(collection)
+        collection = create_stac_collection(
+            products,
+            cadip_session_odata_to_stac_template(),
+            cadip_session_stac_mapper(),
+            collection_provider,
+        )
+        return prepare_collection(collection)
 
-    except json.JSONDecodeError as exception:
-        logger.error(exception)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"JSON Map Error: {exception}",
-        ) from exception
     except ValueError as exception:
         logger.error(exception)
         raise HTTPException(
@@ -623,10 +611,7 @@ def process_files_search(  # pylint: disable=too-many-locals
             page=kwargs.get("page", 1),
         )
 
-        feature_template_path = CADIP_CONFIG / "ODataToSTAC_template.json"
-        with open(feature_template_path, encoding="utf-8") as template:
-            feature_template = json.loads(template.read())
-            cadip_item_collection = create_stac_collection(products, feature_template, cadip_stac_mapper())
+        cadip_item_collection = create_stac_collection(products, cadip_odata_to_stac_template(), cadip_stac_mapper())
         logger.info("Succesfully listed and processed products from CADIP station")
         if kwargs.get("map_to_session", False):
             return [product.properties for product in products]

--- a/services/cadip/rs_server_cadip/api/cadip_search.py
+++ b/services/cadip/rs_server_cadip/api/cadip_search.py
@@ -65,6 +65,7 @@ from rs_server_common.stac_api_common import (
     check_bbox_input,
     create_stac_collection,
     handle_exceptions,
+    split_multiple_values,
 )
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils import (
@@ -598,7 +599,7 @@ def process_files_search(  # pylint: disable=too-many-locals
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing search parameters")
 
     if session_id:
-        queryables["SessionId"] = [sid.strip() for sid in session_id.split(",")] if "," in session_id else session_id
+        queryables["SessionId"] = split_multiple_values(session_id)
 
     if limit < 1:  # type: ignore
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Pagination cannot be less 0")

--- a/services/cadip/rs_server_cadip/cadip_retriever.py
+++ b/services/cadip/rs_server_cadip/cadip_retriever.py
@@ -64,4 +64,4 @@ def init_cadip_provider(station: str) -> EodagProvider:
         return EodagProvider(ext_auth_config, eodag_config, station)
 
     except Exception as exception:
-        raise CreateProviderFailed("Failed to setup eodag") from exception
+        raise CreateProviderFailed(f"Failed to setup eodag for CADIP station {station}") from exception

--- a/services/cadip/rs_server_cadip/cadip_utils.py
+++ b/services/cadip/rs_server_cadip/cadip_utils.py
@@ -53,9 +53,33 @@ def read_conf():
 
 
 @lru_cache
+def cadip_odata_to_stac_template():
+    """Used each time to read the ODataToSTAC_template json template."""
+    with open(CADIP_CONFIG / "ODataToSTAC_template.json", encoding="utf-8") as mapper:
+        config = json.loads(mapper.read())
+    return config  # WARNING: if the caller wants to modify this cached object, he must deepcopy it first
+
+
+@lru_cache
+def cadip_session_odata_to_stac_template():
+    """Used each time to read the cadip_session_ODataToSTAC_template json template."""
+    with open(CADIP_CONFIG / "cadip_session_ODataToSTAC_template.json", encoding="utf-8") as mapper:
+        config = json.loads(mapper.read())
+    return config  # WARNING: if the caller wants to modify this cached object, he must deepcopy it first
+
+
+@lru_cache
 def cadip_stac_mapper():
-    """Used each time to read the cadip_stac_mapper config yaml."""
+    """Used each time to read the cadip_stac_mapper json config."""
     with open(CADIP_CONFIG / "cadip_stac_mapper.json", encoding="utf-8") as mapper:
+        config = json.loads(mapper.read())
+    return config  # WARNING: if the caller wants to modify this cached object, he must deepcopy it first
+
+
+@lru_cache
+def cadip_session_stac_mapper():
+    """Used each time to read the cadip_sessions_stac_mapper json config."""
+    with open(CADIP_CONFIG / "cadip_sessions_stac_mapper.json", encoding="utf-8") as mapper:
         config = json.loads(mapper.read())
     return config  # WARNING: if the caller wants to modify this cached object, he must deepcopy it first
 
@@ -70,12 +94,11 @@ def select_config(configuration_id: str) -> dict | None:
 
 def stac_to_odata(stac_params: dict) -> dict:
     """Convert a parameter directory from STAC keys to OData keys. Return the new directory."""
-    stac_mapper_path = CADIP_CONFIG / "cadip_sessions_stac_mapper.json"
-    with open(stac_mapper_path, encoding="utf-8") as stac_map:
-        stac_mapper = json.loads(stac_map.read())
-        return {
-            stac_mapper.get(stac_key, stac_key): value for stac_key, value in stac_params.items() if value is not None
-        }
+    return {
+        cadip_session_stac_mapper().get(stac_key, stac_key): value
+        for stac_key, value in stac_params.items()
+        if value is not None
+    }
 
 
 def rename_keys(product: dict) -> dict:
@@ -151,7 +174,7 @@ def validate_products(products: eodag.EOProduct):
     return valid_eo_products
 
 
-def cadip_map_mission(platform: str, constellation: str):
+def cadip_map_mission(platform: str, constellation: str) -> str | None:
     """
     Map STAC platform and constellation into OData Satellite.
 
@@ -159,8 +182,8 @@ def cadip_map_mission(platform: str, constellation: str):
     Input: constellation = sentinel-1   Output: A, B, C
     """
     data: dict = map_stac_platform()
-    satellite: None | str = None
-    satellites: None | str = None
+    satellite: str | None = None
+    satellites: str | None = None
     try:
         if platform:
             config = next(sat[platform] for sat in data["satellites"] if platform in sat)

--- a/services/common/config/adgs_queryables.yaml
+++ b/services/common/config/adgs_queryables.yaml
@@ -22,7 +22,7 @@ platform:
   title: platform
   format: string
   description: string
-  enum: ["sentinel-1a", "sentinel-1b", "sentinel-1c", "sentinel-2a", "sentinel-2b", "sentinel-2c", "sentinel-3a", "sentinel-3b", "sentinel-5P"]
+  enum: ["sentinel-1a", "sentinel-1b", "sentinel-1c", "sentinel-1d", "sentinel-2a", "sentinel-2b", "sentinel-2c", "sentinel-3a", "sentinel-3b", "sentinel-5P"]
 constellation:
   type: string
   title: constellation

--- a/services/common/config/cadip_queryables.yaml
+++ b/services/common/config/cadip_queryables.yaml
@@ -22,7 +22,7 @@ platform:
   title: platform
   format: string
   description: string
-  enum: ["sentinel-1a", "sentinel-1b", "sentinel-1c", "sentinel-2a", "sentinel-2b", "sentinel-2c", "sentinel-3a", "sentinel-3b", "sentinel-5P"]
+  enum: ["sentinel-1a", "sentinel-1b", "sentinel-1c", "sentinel-1d", "sentinel-2a", "sentinel-2b", "sentinel-2c", "sentinel-3a", "sentinel-3b", "sentinel-5P"]
 constellation:
   type: string
   title: constellation

--- a/services/common/config/constellation.yaml
+++ b/services/common/config/constellation.yaml
@@ -30,6 +30,11 @@ satellites:
         code: S1C
         serialid: C
         active: false
+    - sentinel-1d:
+        constellation: sentinel-1
+        code: S1D
+        serialid: D
+        active: false
     - sentinel-2a:
         constellation: sentinel-2
         code: S2A

--- a/services/common/rs_server_common/data_retrieval/eodag_provider.py
+++ b/services/common/rs_server_common/data_retrieval/eodag_provider.py
@@ -153,6 +153,11 @@ class EodagProvider(Provider):
         self.client.set_preferred_provider(self.provider)
         self.client.authenticate_provider(self.provider, external_config)
 
+    def _handle_multiple_values(self, mapped_search_args: dict, values: list | str, singular_key: str, plural_key: str):
+        value = values[0] if isinstance(values, list) and len(values) == 1 else values
+        key = plural_key if isinstance(value, list) else singular_key
+        mapped_search_args[key] = ", ".join(f"'{p}'" for p in value) if isinstance(value, list) else f"'{value}'"
+
     def _specific_search(self, **kwargs) -> SearchResult | list:  # pylint: disable=too-many-branches,too-many-locals
         """
         Conducts a search for products using the specified OData arguments.
@@ -184,19 +189,17 @@ class EodagProvider(Provider):
         mapped_search_args: dict[str, str | None] = {}
         if session_id := kwargs.pop("SessionId", None):
             # Map session_id to the appropriate eodag parameter
-            session_id = session_id[0] if len(session_id) == 1 else session_id
-            key = "SessionIds" if isinstance(session_id, list) else "SessionId"
-            value = ", ".join(f"'{s}'" for s in session_id) if isinstance(session_id, list) else f"'{session_id}'"
-            mapped_search_args[key] = value
+            self._handle_multiple_values(mapped_search_args, session_id, "SessionId", "SessionIds")
 
         if kwargs.pop("sessions_search", False):
             # If request is for session search, handle platform - if any provided.
-            platform = kwargs.pop("Satellite", None)
+            if platform := kwargs.pop("Satellite", None):
+                self._handle_multiple_values(mapped_search_args, platform, "platform", "platforms")
 
-            if platform:
-                key = "platforms" if isinstance(platform, list) else "platform"
-                value = ", ".join(f"'{p}'" for p in platform) if isinstance(platform, list) else f"'{platform}'"
-                mapped_search_args[key] = value
+        for auxip_key in ("attr_ptype", "platformSerialIdentifier", "platformShortName"):
+            # Handle AUXIP parameters that can have one or several values
+            if values := kwargs.pop(auxip_key, None):
+                self._handle_multiple_values(mapped_search_args, values, auxip_key, auxip_key + "s")
 
         if date_time := kwargs.pop("PublicationDate", False):
             # Since now both for files and sessions, time interval is optional, map it if provided.

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -17,6 +17,7 @@
 """Module to share common functionalities for validating / creating stac items"""
 import copy
 import json
+import os
 import re
 import urllib.parse
 from abc import ABC, abstractmethod
@@ -694,7 +695,8 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
             logger.debug(f"Entity {odata_entity} matches {crit_type} criteria {key}={value}")
 
         def nomatch(odata_entity: dict, crit_type: str, key: str, value: str):
-            logger.debug(f"Entity {odata_entity} does not match {crit_type} criteria {key}={value}")
+            if os.getenv("PYTHONDEBUG", "False").lower() in ("1", "true", "yes"):
+                logger.debug(f"Entity {odata_entity} does not match {crit_type} criteria {key}={value}")
             return False
 
         for crit_key, crit_val in query.items():

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -18,10 +18,9 @@
 import copy
 import json
 import re
-import threading
-import traceback
 import urllib.parse
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
@@ -34,6 +33,7 @@ from typing import (
     Literal,
     Optional,
     Self,
+    TypeAlias,
 )
 
 import stac_pydantic
@@ -52,6 +52,7 @@ from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils import (
     extract_eo_product,
     odata_to_stac,
+    run_in_threads,
     validate_inputs_format,
 )
 from stac_fastapi.api.models import Limit
@@ -68,8 +69,12 @@ def log_http_exception(*args, **kwargs) -> HTTPException:
     return utils2.log_http_exception(logger, *args, **kwargs)
 
 
+DEFAULT_STAC_VERSION = "1.0.0"
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 SEARCH_LIMIT = 10000  # max number of products returned by eodag
+
+DATE_INTERVAL_KEYS = ["PublicationDate"]
+COMMA_SEPARATED_LISTS_KEYS = ["platformSerialIdentifier", "platformShortName", "Satellite", "productType"]
 
 # Type hints
 CollectionType = Annotated[str, FPath(description="Collection ID", max_length=100)]
@@ -108,6 +113,7 @@ LimitType = Annotated[
     ),
 ]
 PageType = Annotated[Optional[str], Query(description="Page number to be displayed, defaults to first one.")]
+ServiceRole: TypeAlias = Literal["auxip", "cadip"]
 
 
 class Queryables(BaseModel):
@@ -149,13 +155,13 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
     request: Request = Request(scope={"type": "http"})
     readwrite: Literal["r", "w"] | None = None
 
-    service: Literal["auxip", "cadip"] | None = None
+    service: ServiceRole | None = None
 
     # auxip or cadip function
-    all_collections: Callable = lambda: None
-    select_config: Callable = lambda: None
-    stac_to_odata: Callable = lambda: None
-    map_mission: Callable = lambda: None
+    all_collections: Callable[[], list[dict]] = lambda: []
+    select_config: Callable[[str], dict] = lambda _id: {}
+    stac_to_odata: Callable[[dict], dict] = lambda _d: {}
+    map_mission: Callable[[Any | None, Any | None], str | tuple | None] = lambda _p, _c: None
     temporal_mapping: dict[str, str] | None = None
 
     # Is the service auxip or cadip ?
@@ -205,8 +211,8 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
         # TODO: factorize this code for all query parameters.
         if self.auxip:
             can_query = True
-            if collection_id:
-                value = self.select_config(collection_id).get("query", {}).get("productType", "")
+            if collection_id and (collection := self.select_config(collection_id)):
+                value = collection.get("query", {}).get("productType", "")
                 if value and ("," not in value):
                     can_query = False
             if can_query:
@@ -217,9 +223,10 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
 
         # Idem for satellite or platform
         can_query = True
-        if collection_id:
+        if collection_id and (collection := self.select_config(collection_id)):
+            query_dict = collection.get("query") or {}
             for field in "platformSerialIdentifier", "platformShortName", "Satellite":
-                value = (self.select_config(collection_id).get("query") or {}).get(field) or ""
+                value = query_dict.get(field) or ""
                 if value and ("," not in value):
                     can_query = False
                     break
@@ -262,7 +269,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                 )
 
             # Convert into stac object (to ensure validity) then back to dict
-            collection.setdefault("stac_version", "1.0.0")
+            collection.setdefault("stac_version", DEFAULT_STAC_VERSION)
             return create_collection(collection).model_dump()
 
         # from stac_fastapi.pgstac.extensions.filter.FiltersClient::get_queryables
@@ -345,7 +352,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                     params[key] = values
 
         # Collections to search
-        collection_ids = [collection.strip() for collection in params.pop("collections", [])]
+        collection_ids: list[str] = [collection.strip() for collection in params.pop("collections", [])]
 
         # IDs to search
         ids = params.pop("ids", None)
@@ -535,9 +542,9 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
         mission = self.map_mission(stac_params.get("platform"), stac_params.get("constellation"))
         # ... still saved with stac keys for now
         if self.auxip:
-            stac_params["constellation"], stac_params["platform"] = mission
+            stac_params["constellation"], stac_params["platform"] = mission  # type: ignore
         if self.cadip:
-            stac_params["platform"] = mission
+            stac_params["platform"] = mission  # type: ignore
 
         # Discard these search parameters
         params.pop("bbox", None)
@@ -559,25 +566,187 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
         #
         # Step 2: do the search
 
+        # Convert search params from STAC keys to OData keys
+        odata_params: dict = self.stac_to_odata(stac_params)
+        logger.debug(f"STAC/OData parameters mapping: {stac_params} => {odata_params}")
+
         # Only keep the authorized collections
-        allowed = filter_allowed_collections(self.all_collections(), self.service, self.request)
-        allowed_ids = {collection["id"] for collection in allowed}
-        if not collection_ids:
-            collection_ids = list(allowed_ids)
-        else:
-            collection_ids = list(allowed_ids.intersection(collection_ids))
+        allowed: list[dict] = filter_allowed_collections(self.all_collections(), self.service, self.request)
+        allowed_ids: set[str] = {collection["id"] for collection in allowed}
+        all_results: list[Sequence[Item] | Exception] = (
+            self.search_collections_by_station(list(allowed_ids.intersection(collection_ids)), odata_params, True)
+            if collection_ids
+            else self.search_collections_by_station(list(allowed_ids), odata_params, False)
+        )
 
-        # Search all collections in parallel threads
-        all_results: list[Sequence[Item] | Exception] = []
-        threads = [
-            threading.Thread(target=self.process_collection, args=(collection_id, stac_params, all_results))
-            for collection_id in collection_ids
+        # Return results as a dict
+        return self.build_response_payload(self.aggregate_items_from_results(all_results))
+
+    def search_collections_by_station(
+        self,
+        collection_ids: list[str],
+        odata_params: dict,
+        aggregate_search_params: bool = True,
+    ) -> list[Sequence[Item] | Exception]:
+        """
+        Performs a search for items across multiple stations, grouped by their collection configurations.
+
+        This method groups collections by their associated station, optionally merges and aggregates
+        OData search parameters per station, and executes the searches in parallel threads.
+        If multiple collections belong to the same station, and `aggregate_search_params` is True,
+        their queries are merged to reduce the number of calls.
+
+        Args:
+            collection_ids (list[str]): List of collection identifiers to search within.
+            odata_params (dict): User-defined OData search parameters to apply to all stations.
+            aggregate_search_params (bool, optional): If True, merge search parameters for collections
+                of the same station. Defaults to True.
+
+        Returns:
+            list[Sequence[Item] | Exception]: A list of either successful item results or raised exceptions,
+            one per station.
+        """
+        # Group collections by station
+        collections_by_station: dict[str, list[dict]] = defaultdict(list)
+        for collection in (self.select_config(collection_id) for collection_id in collection_ids):
+            collections_by_station[collection["station"]].append(collection)
+
+        odata_params_by_station: dict[str, dict] = {}
+        for station, station_collections in collections_by_station.items():
+            if aggregate_search_params:
+                # Aggregates all search params for this station to make a single call
+                odata_merged = odata_params.copy()
+                empty_selection = False
+                for collection in station_collections:
+                    # Some OData search params are hardcoded in the collection configuration
+                    odata_hardcoded = collection.get("query") or {}
+
+                    # Merge the user input params with the hardcoded params (which have higher priority)
+                    odata_merged, empty_selection = self.merge_odata_params(odata_hardcoded, odata_merged)
+                    if empty_selection:
+                        logger.warning("Key conflict resolution lead to empty selection, skipping search to {station}")
+                        break
+                if not empty_selection:
+                    odata_params_by_station[station] = odata_merged
+            else:
+                # Do the same search for all stations
+                odata_params_by_station[station] = odata_params
+
+        # Search all stations in parallel threads
+        return run_in_threads(
+            self.perform_search_in_station,
+            (
+                (
+                    station,
+                    station_odata_params,
+                    lambda odata_entity, station=station: self.determine_collection(
+                        odata_entity,
+                        collections_by_station[station],
+                    ),
+                    self.filter_items_without_collection,
+                )
+                for station, station_odata_params in odata_params_by_station.items()
+            ),
+        )
+
+    def determine_collection(self, odata_entity: dict, collections: list[dict]) -> str | None:
+        """
+        Determines the matching collection ID for a given OData entity.
+
+        This method iterates over a list of collection configurations and checks
+        which one the OData entity satisfies based on the collection's query criteria.
+        Returns the first matching collection ID or None if no match is found.
+
+        Args:
+            odata_entity (dict): The OData entity to evaluate.
+            collections (list[dict]): A list of collection configurations,
+            each potentially containing query criteria.
+
+        Returns:
+            str | None: The ID of the first matching collection, or None if no match is found.
+        """
+        for collection in collections:
+            if self.is_entity_matching_all_criteria(odata_entity, collection.get("query") or {}):
+                return collection["id"]
+        return None
+
+    def is_entity_matching_all_criteria(self, odata_entity: dict, query: dict) -> bool:
+        """
+        Evaluates whether an OData entity matches all criteria defined in a query.
+
+        The query may contain various types of filters including:
+        - Fixed dates or date intervals (keys in DATE_INTERVAL_KEYS)
+        - Comma-separated list values (keys in COMMA_SEPARATED_LISTS_KEYS)
+        - Exact value matches
+
+        The function logs whether each criterion was matched or not, and returns False
+        as soon as a mismatch is detected. If all criteria are matched, it returns True.
+
+        Args:
+            odata_entity (dict): The OData entity to validate.
+            query (dict): A dictionary of filter criteria.
+
+        Returns:
+            bool: True if all criteria are matched by the entity, False otherwise.
+        """
+
+        def match(odata_entity: dict, crit_type: str, key: str, value: str):
+            logger.debug(f"Entity {odata_entity} matches {crit_type} criteria {key}={value}")
+
+        def nomatch(odata_entity: dict, crit_type: str, key: str, value: str):
+            logger.debug(f"Entity {odata_entity} does not match {crit_type} criteria {key}={value}")
+            return False
+
+        for crit_key, crit_val in query.items():
+            if crit_key not in ("top", "skip", "orderby"):
+                value = odata_entity.get(crit_key, None)
+                if crit_key in DATE_INTERVAL_KEYS:
+                    date = dt.fromisoformat(value) if value else None
+                    fixed, start, stop = validate_inputs_format(crit_val, raise_errors=False)
+                    if fixed and date != fixed:
+                        return nomatch(odata_entity, "fixed date", crit_key, crit_val)
+                    if start and stop and not start <= date <= stop:
+                        return nomatch(odata_entity, "closed interval", crit_key, crit_val)
+                    if (start and date < start) or (stop and date > stop):
+                        return nomatch(odata_entity, "open interval", crit_key, crit_val)
+                    match(odata_entity, "date", crit_key, crit_val)
+                elif crit_key in COMMA_SEPARATED_LISTS_KEYS:
+                    iterable = crit_val if isinstance(crit_val, list) else crit_val.split(",")
+                    if value not in {v.strip() for v in iterable}:
+                        return nomatch(odata_entity, "list", crit_key, crit_val)
+                    match(odata_entity, "list", crit_key, crit_val)
+                elif crit_val != odata_entity.get(crit_key, None):
+                    return nomatch(odata_entity, "generic", crit_key, crit_val)
+                else:
+                    match(odata_entity, "generic", crit_key, crit_val)
+        return True
+
+    def filter_items_without_collection(self, items: list[Item]) -> None:
+        """
+        Removes items from the list that do not have a 'collection' field.
+
+        Args:
+            items (list[Item]): The list of items to filter (modified in place).
+        """
+        items[:] = [
+            item for item in items if item.collection or not logger.warning(f"Filter item without collection: {item}")
         ]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
 
+    def aggregate_items_from_results(self, all_results) -> ItemCollection:
+        """
+        Aggregates items from a list of results, filtering out exceptions and ensuring unique items by ID.
+
+        If all results are exceptions (i.e., no valid items), the first exception is raised.
+
+        Args:
+            all_results (Iterable[Sequence[Item] | Exception]): A list of either sequences of items or exceptions.
+
+        Returns:
+            ItemCollection: A collection containing all unique items combined into a STAC ItemCollection.
+
+        Raises:
+            Exception: The first exception encountered if no valid items are present.
+        """
         # Get items and exceptions from result
         all_items = {}
         all_exceptions = []
@@ -593,7 +762,22 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
             raise all_exceptions[0]
 
         # Return results as a dict
-        data = ItemCollection(features=list(all_items.values()), type="FeatureCollection")
+        return ItemCollection(features=list(all_items.values()), type="FeatureCollection")
+
+    def build_response_payload(self, data: ItemCollection) -> dict[str, Any]:
+        """
+        Builds the search response payload by handling pagination and CADIP asset processing.
+
+        This method adapts the response structure based on the request path (e.g., `/search`)
+        and applies additional processing for CADIP-specific data when needed.
+
+        Args:
+            data (ItemCollection): The item collection returned from aggregate_items_from_results.
+
+        Returns:
+            dict[str, Any]: A dictionary-formatted payload ready for response, potentially including pagination links
+            and enriched asset information for CADIP sessions.
+        """
         if "/search" in self.request.url.path:
             # Do the custom pagination only for search endpoints, for others let eodag handle on station side.
             dict_data: dict[str, Any] = self.paginate(data)
@@ -625,117 +809,175 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
             type=paginated_item_collection.type,
         ).model_dump()
 
-    def process_collection(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
-        self,
-        collection_id: str,
-        stac_params: dict,
-        return_values: list[Sequence[Item] | Exception],
-    ):
-        """Method used to process a collection and perform search."""
-        features = None
+    def merge_odata_params(self, odata_hardcoded: dict, odata_params: dict) -> tuple[dict, bool]:
+        """
+        Merges hardcoded and user-provided OData parameters with conflict resolution logic.
+
+        Hardcoded parameters take precedence in the merge. If a parameter exists in both sources,
+        conflicts are resolved based on the parameter type:
+        - For date intervals (e.g., "PublicationDate"), the intersection is computed.
+        - For comma-separated lists (e.g., "platformShortName", "productType"), the common values are retained.
+
+        Args:
+            odata_hardcoded (dict): Hardcoded parameters defined in the collection configuration.
+            odata_params (dict): OData parameters provided by the user.
+
+        Returns:
+            tuple[dict, bool]: A tuple containing the merged OData parameters and a boolean flag indicating
+            whether the result of the merge leads to an empty selection (e.g., no intersecting values).
+        """
+        # Merge the user input params with the hardcoded params (which have higher priority)
+        odata_merged = {**odata_params, **odata_hardcoded}
         empty_selection = False
-        # Convert search params from STAC keys to OData keys
-        odata_params = self.stac_to_odata(stac_params)
-        logger.debug(f"STAC/OData parameters mapping: {stac_params} => {odata_params}")
-        try:
-            # Some OData search params are hardcoded in the collection configuration.
-            collection = self.select_config(collection_id)
-            odata_hardcoded = collection.get("query") or {}
 
-            # Merge the user input params with the hardcoded params (which have higher priority)
-            odata_merged = {**odata_params, **odata_hardcoded}
+        # Handle conflicts, i.e. for each key that is defined in both params
+        for key in sorted(set(odata_params) & set(odata_hardcoded)):
+            key_empty_selection = False
+            # Date intervals
+            if key in DATE_INTERVAL_KEYS:
+                odata_merged[key], key_empty_selection = self.resolve_date_interval_conflict(
+                    odata_params[key],
+                    odata_hardcoded[key],
+                )
+            # Comma-separated lists
+            elif key in COMMA_SEPARATED_LISTS_KEYS:
+                odata_merged[key], key_empty_selection = self.resolve_comma_separated_list_conflict(
+                    odata_params[key],
+                    odata_hardcoded[key],
+                )
+            else:
+                logger.warning(f"No conflict resolution performed for key {key}")
+            if key_empty_selection:
+                empty_selection = True
 
-            # Handle conflicts, i.e. for each key that is defined in both params
-            for key in set(odata_params.keys()).intersection(odata_hardcoded.keys()):
-                # Date intervals
-                if key in ("PublicationDate"):
+        return odata_merged, empty_selection
 
-                    # Read both start and stop dates
-                    _, start1, stop1 = validate_inputs_format(odata_params[key], raise_errors=True)
-                    _, start2, stop2 = validate_inputs_format(odata_hardcoded[key], raise_errors=True)
+    def resolve_date_interval_conflict(self, value1: str, value2: str) -> tuple[str, bool]:
+        """
+        Resolves a conflict between two date interval strings by computing their intersection.
 
-                    # Calculate the intersection
-                    start = max(start1, start2)
-                    stop = min(stop1, stop2)
+        Args:
+            value1 (str): The first date interval in ISO 8601 format.
+            value2 (str): The second date interval in ISO 8601 format.
 
-                    # If no intersection, then the selection is empty, else save the intersection
-                    if start >= stop:
-                        empty_selection = True
-                        break  # try next collection
-                    odata_merged[key] = f"{start.strftime(DATETIME_FORMAT)}/{stop.strftime(DATETIME_FORMAT)}"
-                # Comma-separated lists
-                if key in ("platformSerialIdentifier", "platformShortName", "Satellite", "productType"):
+        Returns:
+            tuple[str, bool]: A tuple containing the intersected date interval as a string,
+                and a boolean indicating whether the selection is empty (True if no overlap).
+        """
+        logger.debug(f"Resolving date interval conflict resolution between {value1} and {value2}")
 
-                    # Read both values
-                    value1 = odata_params[key]
-                    value2 = odata_hardcoded[key]
-                    intersection = None
+        # Read both start and stop dates
+        _, start1, stop1 = validate_inputs_format(value1, raise_errors=True)
+        _, start2, stop2 = validate_inputs_format(value2, raise_errors=True)
 
-                    # If one is empty or None, this means "keep everything".
-                    # So keep the intersection = the other list.
-                    if not value1:
-                        intersection = value2
-                    elif not value2:
-                        intersection = value1
+        # Calculate the intersection
+        start = max(start1, start2)
+        stop = min(stop1, stop2)
 
-                    # Else, split by comma and keep the intersection.
-                    # If no intersection, then the selection is empty.
-                    else:
-                        for i, value in enumerate((value1, value2)):
-                            iterable = value if isinstance(value, list) else value.split(",")
-                            s = {v.strip() for v in iterable}
-                            intersection = intersection.intersection(s) if i else s  # type: ignore
-                        if intersection:
-                            intersection = ", ".join(intersection)
-                        if not intersection:
-                            empty_selection = True
-                            break  # try next collection
+        return f"{start.strftime(DATETIME_FORMAT)}/{stop.strftime(DATETIME_FORMAT)}", start >= stop
 
-                    # Save the intersection
-                    odata_merged[key] = intersection
-            if empty_selection:
-                return
+    def resolve_comma_separated_list_conflict(self, value1: Any, value2: Any) -> tuple[Any, bool]:
+        """
+        Resolves a conflict between two comma-separated lists by computing their intersection.
 
-            # limit and page values used by the search function
-            search_limit = self.limit
-            search_page = self.page
+        Args:
+            value1 (Any): The first list, or a comma-separated string representing it.
+            value2 (Any): The second list, or a comma-separated string representing it.
 
-            # Don't forward limit value for /search endpoints
-            # just use maximum to gather all possible results, page is always 1
-            if "/search" in self.request.url.path:
-                search_limit = self.limit * self.page
-                search_page = 1
+        Returns:
+            tuple[Any, bool]: A tuple containing the intersected list as a comma-separated string,
+            and a boolean indicating whether the result is empty (True if no intersection).
+        """
+        logger.debug(f"Resolving comma-separated list conflict resolution between {value1} and {value2}")
 
-            # Do the search for this collection
-            logger.debug(f"Searching with OData parameters {odata_merged}")
-            features = (self.process_search(collection, odata_merged, search_limit, search_page)).features
+        intersection = None
 
-            # If search return maximum number of elements, increase page and process next elements
-            if len(features) == SEARCH_LIMIT:
-                while True:
-                    search_page += 1
-                    next_features = (self.process_search(collection, odata_merged, search_limit, search_page)).features
-                    features.extend(next_features)  # type: ignore
-                    # Extend current features.
-                    # Break the loop when result is less the maximum possible, meaning there is no next page.
-                    if len(next_features) < SEARCH_LIMIT:
-                        break
-                search_page = 1
+        # If one is empty or None, this means "keep everything".
+        # So keep the intersection = the other list.
+        if not value1:
+            intersection = value2
+        elif not value2:
+            intersection = value1
 
-            # Add the collection information
-            for item in features:
-                item.collection = collection_id
-            return_values.append(features)
+        # Else, split by comma and keep the intersection.
+        # If no intersection, then the selection is empty.
+        else:
+            for i, value in enumerate((value1, value2)):
+                iterable = value if isinstance(value, list) else value.split(",")
+                s = {v.strip() for v in iterable}
+                intersection = intersection.intersection(s) if i else s  # type: ignore
+            intersection = ", ".join(intersection) if intersection else None
+            logger.debug(f"comma-separated list conflict resolution result: {intersection}")
 
-        except Exception as exception:  # pylint: disable=broad-exception-caught
-            logger.error(traceback.format_exc())
-            return_values.append(exception)
+        return intersection, not intersection
+
+    def perform_search_in_station(
+        self,
+        station: str,
+        odata_params: dict,
+        collection_provider: Callable[[dict], str | None],
+        postprocess: Callable[[list[Item]], None],
+    ) -> list[Item]:
+        """
+        Performs a paginated search for items from a given station.
+
+        This method handles pagination automatically by fetching subsequent pages
+        if the number of results equals the search limit.
+        Applies a postprocessing function to the final list of items before returning.
+
+        Args:
+            station (str): The station to search in.
+            odata_params (dict): The OData query parameters to use for filtering the results.
+            collection_provider (Callable[[dict], str | None]): Function that determines STAC collection
+                                                                for a given OData entity
+            postprocess (Callable[[list[Item]], None]): Function to modify the list of items.
+
+        Returns:
+            Sequence[Item]: A list of STAC items matching the search criteria, postprocessed.
+        """
+        # limit and page values used by the search function
+        search_limit = self.limit
+        search_page = self.page
+
+        # Don't forward limit value for /search endpoints
+        # just use maximum to gather all possible results, page is always 1
+        if "/search" in self.request.url.path:
+            search_limit = self.limit * self.page
+            search_page = 1
+
+        # Do the search for this station
+        logger.debug(f"Searching to {station} station with OData parameters {odata_params}")
+        features = self.process_search(station, odata_params, collection_provider, search_limit, search_page).features
+
+        # If search return maximum number of elements, increase page and process next elements
+        if len(features) == SEARCH_LIMIT:
+            while True:
+                search_page += 1
+                next_features = self.process_search(
+                    station,
+                    odata_params,
+                    collection_provider,
+                    search_limit,
+                    search_page,
+                ).features
+                features.extend(next_features)  # type: ignore
+                # Extend current features.
+                # Break the loop when result is less the maximum possible, meaning there is no next page.
+                if len(next_features) < SEARCH_LIMIT:
+                    break
+            search_page = 1
+
+        logger.debug(f"Items found before post-processing: {len(features)}")
+        postprocess(features)
+        logger.debug(f"Items kept after post-processing: {len(features)}")
+        return features
 
     @abstractmethod
     def process_search(
         self,
-        collection: dict,
+        station: str,
         odata_params: dict,
+        collection_provider: Callable[[dict], str | None],
         limit: int,
         page: int,
     ) -> ItemCollection:
@@ -800,11 +1042,11 @@ def handle_exceptions(func: Callable[..., Any]) -> Callable[..., Any]:
     return utils2.decorate_sync_async(wrapping_logic, func)
 
 
-def filter_allowed_collections(all_collections, role, request):
+def filter_allowed_collections(all_collections: list[dict], role: ServiceRole | None, request: Request) -> list[dict]:
     """Filters collections based on user roles and permissions.
 
     This function returns only the collections that a user is allowed to read based on their
-    assigned roles in KeyCloak. If the application is running in local mode, all collections
+    assigned roles in Keycloak. If the application is running in local mode, all collections
     are returned without filtering.
 
     Parameters:
@@ -816,9 +1058,8 @@ def filter_allowed_collections(all_collections, role, request):
                            available through `request.state.auth_roles`.
 
     Returns:
-        dict: A JSON object containing the type, links, and a list of filtered collections
-              that the user is allowed to access. The structure of the returned object is
-              as follows:
+        list[dict]: list of filtered collections that the user is allowed to access.
+              The structure of the returned objects is as follows:
               - type (str): The type of the STAC object, which is always "Object".
               - links (list): A list of links associated with the STAC object (currently empty).
               - collections (list[dict]): A list of filtered collections, where each collection
@@ -853,9 +1094,9 @@ def filter_allowed_collections(all_collections, role, request):
     logger.debug(f"User allowed collections: {[collection['id'] for collection in filtered_collections]}")
 
     # Foreach allowed collection, create links and append to response.
-    stac_collections = []
+    stac_collections: list[dict] = []
     for config in filtered_collections:
-        config.setdefault("stac_version", "1.0.0")
+        config.setdefault("stac_version", DEFAULT_STAC_VERSION)
         try:
             collection: stac_pydantic.Collection = create_collection(config)
             stac_collections.append(collection.model_dump())
@@ -894,6 +1135,7 @@ def create_stac_collection(
     products: list[Any],
     feature_template: dict,
     stac_mapper: dict,
+    collection_provider: Callable[[dict], str | None] | None = None,
 ) -> ItemCollection:
     """
     Creates a STAC feature collection based on a given template for a list of EOProducts.
@@ -902,6 +1144,8 @@ def create_stac_collection(
         products (List[EOProduct]): A list of EOProducts to create STAC features for.
         feature_template (dict): The template for generating STAC features.
         stac_mapper (dict): The mapping dictionary for converting EOProduct data to STAC properties.
+        collection_provider (Callable[[dict], str | None]): optional function that determines STAC collection
+                                                            for a given OData entity
 
     Returns:
         dict: The STAC feature collection containing features for each EOProduct.
@@ -910,7 +1154,7 @@ def create_stac_collection(
 
     for product in products:
         product_data = extract_eo_product(product, stac_mapper)
-        feature_tmp = odata_to_stac(copy.deepcopy(feature_template), product_data, stac_mapper)
+        feature_tmp = odata_to_stac(copy.deepcopy(feature_template), product_data, stac_mapper, collection_provider)
         try:
             item = Item(**feature_tmp)
             item.stac_extensions = [str(se) for se in item.stac_extensions]  # type: ignore

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -1250,3 +1250,21 @@ def check_bbox_input(input_value: str | None) -> BBox | None:
         except Exception as e:
             raise log_http_exception(status.HTTP_400_BAD_REQUEST, str(e)) from e
     return None
+
+
+def split_multiple_values(input_value: str) -> list[str] | str:
+    """
+    Splits a comma-separated string into a list of trimmed strings.
+
+    If the input string contains commas, it is split on each comma and each resulting
+    substring is stripped of leading and trailing whitespace. If no comma is found,
+    the original string is returned unchanged.
+
+    Args:
+        input_value (str): The input string to process.
+
+    Returns:
+        list[str] | str: A list of trimmed strings if the input contains commas,
+                         otherwise the original string.
+    """
+    return [s.strip() for s in input_value.split(",")] if "," in input_value else input_value

--- a/services/common/rs_server_common/utils/utils.py
+++ b/services/common/rs_server_common/utils/utils.py
@@ -14,7 +14,11 @@
 
 """This module is used to share common functions between apis endpoints"""
 
+import traceback
+from collections.abc import Callable, Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from threading import Thread
 from typing import Any
 
 from eodag import EOProduct
@@ -83,7 +87,7 @@ def validate_str_list(parameter: str) -> list | str:
 def validate_inputs_format(
     date_time: str,
     raise_errors: bool = True,
-) -> Any:
+) -> tuple[datetime | None, datetime | None, datetime | None]:
     """
     Validate the format and content of a time interval string.
 
@@ -136,7 +140,7 @@ def validate_inputs_format(
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing start/stop")
             return None, None, None
 
-    def to_dt(dates) -> list[Any]:
+    def to_dt(dates) -> list[datetime | None]:
         """Converts a list of date strings to datetime objects or None if the conversion fails."""
         return [datetime.fromisoformat(date) if is_valid_date(date) else None for date in dates]
 
@@ -164,7 +168,12 @@ def validate_inputs_format(
     return fixed_date_dt, start_date_dt, stop_date_dt
 
 
-def odata_to_stac(feature_template: dict, odata_dict: dict, odata_stac_mapper: dict) -> dict:
+def odata_to_stac(
+    feature_template: dict,
+    odata_dict: dict,
+    odata_stac_mapper: dict,
+    collection_provider: Callable[[dict], str | None] | None = None,
+) -> dict:
     """
     Maps OData values to a given STAC template.
 
@@ -172,6 +181,8 @@ def odata_to_stac(feature_template: dict, odata_dict: dict, odata_stac_mapper: d
         feature_template (dict): The STAC feature template to be populated.
         odata_dict (dict): The dictionary containing OData values.
         odata_stac_mapper (dict): The mapping dictionary for converting OData keys to STAC properties.
+        collection_provider (Callable[[dict], str | None]): optional function that determines STAC collection
+                                                            for a given OData entity
 
     Returns:
         dict: The populated STAC feature template.
@@ -193,6 +204,9 @@ def odata_to_stac(feature_template: dict, odata_dict: dict, odata_stac_mapper: d
             feature_template["properties"].pop(stac_key, None)
     # to pass pydantic validation, make sure we don't have a single timerange value
     check_and_fix_timerange(feature_template)
+    # determine item collection
+    if collection_provider:
+        feature_template["collection"] = collection_provider(odata_dict)
     return feature_template
 
 
@@ -231,3 +245,41 @@ def validate_sort_input(sortby: str):
 def strftime_millis(date: datetime):
     """Format datetime with milliseconds precision"""
     return date.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def run_threads(threads: Iterable[Thread]) -> None:
+    """Start all threads, then join them."""
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+def run_in_threads(
+    func: Callable[..., Any],
+    args_list: Sequence[tuple],
+    max_workers: int | None = None,
+) -> list[Any]:
+    """
+    Executes a function in parallel using threads, and returns the list of non-None results.
+
+    Each thread runs `func` with the corresponding arguments provided in `args_list`.
+
+    Args:
+        func (Callable[..., Any]): The function to be executed concurrently.
+        args_list (Sequence[tuple]): A sequence of argument tuples for each thread.
+        max_workers (int | None): The maximum number of threads to use.
+
+    Returns:
+        list[Any]: A list of results, one per thread, excluding any result that is None, in the same order as args_list.
+    """
+    results: list[Any] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for future in [executor.submit(func, *args) for args in args_list]:
+            try:
+                if (result := future.result()) is not None:
+                    results.append(result)
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                logger.error(traceback.format_exc())
+                results.append(e)
+    return results

--- a/services/common/rs_server_common/utils/utils2.py
+++ b/services/common/rs_server_common/utils/utils2.py
@@ -72,7 +72,7 @@ def log_http_exception(
     ] = None,
     exception_type: type[HTTPException] = HTTPException,
 ) -> type[HTTPException]:
-    """Log error and return an HTTP execption to be raised by the caller"""
+    """Log error and return an HTTP exception to be raised by the caller"""
     logger.error(detail)
     return exception_type(status_code, detail, headers)  # type: ignore
 
@@ -83,7 +83,7 @@ def read_response_error(response):
     # Try to read the response detail or error
     try:
         json = response.json()
-        detail = json.get("detail") or json["error"]
+        detail = json.get("detail") or json.get("description") or json["error"]
 
     # If this fail, get the full response content
     except Exception:  # pylint: disable=broad-exception-caught

--- a/tests/test_authentication_to_external.py
+++ b/tests/test_authentication_to_external.py
@@ -21,7 +21,10 @@ import datetime
 import json
 import os
 import re
+from copy import deepcopy
 from importlib import reload
+from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
@@ -29,6 +32,7 @@ import yaml
 from eodag.plugins.authentication.token import TokenAuth
 from fastapi import HTTPException
 from fastapi.concurrency import run_in_threadpool
+from requests import PreparedRequest
 from rs_server_adgs import adgs_retriever, adgs_utils
 from rs_server_cadip import cadip_retriever, cadip_utils
 from rs_server_common.authentication import authentication_to_external
@@ -970,12 +974,14 @@ async def test_set_eodag_auth_token_called_once(  # pylint: disable=too-many-loc
         suffix = "_session" if cadip else ""
         all_providers = sorted({collection["station"] + suffix for collection in collections})
 
-    def mock_station_response(request):
+    def mock_station_response(request: PreparedRequest):
         if adgs:
-            body = adgs_response
+            body: dict[str, Any] = adgs_response
         else:  # cadip
             if request.path_url.startswith("/Sessions"):
-                body = cadip_session_response
+                body = deepcopy(cadip_session_response)
+                if sat := parse_qs(urlparse(request.url or "").query).get("Satellite"):
+                    body["Satellite"] = sat[0]
             else:
                 body = cadip_file_response
         return HTTP_200_OK, r_headers, json.dumps(body)
@@ -989,9 +995,9 @@ async def test_set_eodag_auth_token_called_once(  # pylint: disable=too-many-loc
             content_type=content_type,
         )
 
-    all_requests = []
+    all_requests: list[PreparedRequest] = []
 
-    def mock_token_request(request):
+    def mock_token_request(request: PreparedRequest):
 
         # Save the request
         all_requests.append(request)
@@ -1046,7 +1052,9 @@ async def test_set_eodag_auth_token_called_once(  # pylint: disable=too-many-loc
     # Assert that the refresh_token was not called
     assert len(all_requests) == len(all_providers)
     for request in all_requests:
-        assert "refresh_token" not in request.body
+        body = request.body
+        if isinstance(body, (str, bytes)):
+            assert b"refresh_token" not in body if isinstance(body, bytes) else "refresh_token" not in body
     all_requests.clear()
 
     # If we call the search again, no token should be requested, because the token is still valid
@@ -1065,4 +1073,6 @@ async def test_set_eodag_auth_token_called_once(  # pylint: disable=too-many-loc
     # Assert that the refresh_token was called
     assert len(all_requests) == len(all_providers)
     for request in all_requests:
-        assert "refresh_token" in request.body
+        body = request.body
+        if isinstance(body, (str, bytes)):
+            assert b"refresh_token" in body if isinstance(body, bytes) else "refresh_token" in body

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -1708,9 +1708,9 @@ def test_search_parameters(
                     "(PublicationDate gt {date_min} or PublicationDate eq {date_min}) and "
                     "(PublicationDate lt {date_max} or PublicationDate eq {date_max}) "
                     "and Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' "
-                    "and att/OData.CSC.StringAttribute/Value eq '{product_type}') "
+                    "and att/OData.CSC.StringAttribute/Value {product_type_op} {product_type}) "
                     "and Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'platformShortName' "
-                    "and att/OData.CSC.StringAttribute/Value eq '{constellation}')"
+                    "and att/OData.CSC.StringAttribute/Value {constellation_op} {constellation})"
                     "&$orderby=PublicationDate%20asc&$top=15&$skip=0&$expand=Attributes"
                 )
             elif cadip:
@@ -1792,18 +1792,31 @@ def test_search_parameters(
                     # Format the odata request with all possible parameters
                     if adgs:
                         constellation = constellation.upper()
-                    if "," in satellite:
-                        sats = ", ".join([f"'{sat}'" for sat in satellite.split(", ")])
-                        satellite = f"({sats})"
-                    else:
-                        satellite = f"'{satellite}'"
+
+                    def handle_multiple_values(value: str) -> str:
+                        if value is None:
+                            return None
+                        if "," in value:
+                            values = ", ".join([f"'{val}'" for val in value.split(", ")])
+                            return f"({values})"
+                        return f"'{value}'"
+
+                    def in_or_eq(value: str) -> str:
+                        return None if value is None else "in" if "," in value else "eq"
+
+                    product_type = handle_multiple_values(product_type)
+                    constellation = handle_multiple_values(constellation)
+                    satellite = handle_multiple_values(satellite)
+
                     odata = odata.format(
                         date_min=date_min,
                         date_max=date_max,
                         product_type=product_type,
+                        product_type_op=in_or_eq(product_type),
                         constellation=constellation,
+                        constellation_op=in_or_eq(constellation),
                         satellite=satellite,
-                        satellite_op="in" if "," in satellite else "eq",
+                        satellite_op=in_or_eq(satellite),
                     )
 
                     # Mock the reponse

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -109,7 +109,7 @@ class TestConstellationMapping:
             ("sentinel-2b", "sentinel-2", "S2B"),
             ("sentinel-1a", "sentinel-1", "S1A"),
             ("sentinel-5p", "sentinel-5P", "S5P"),
-            (None, "sentinel-1", "S1A, S1B, S1C"),
+            (None, "sentinel-1", "S1A, S1B, S1C, S1D"),
             (None, "sentinel-2", "S2A, S2B, S2C"),
             (None, "sentinel-5P", "S5P"),
         ],

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -31,6 +31,7 @@ from rs_server_adgs.adgs_utils import auxip_map_mission
 from rs_server_cadip import cadip_utils
 from rs_server_cadip.cadip_utils import cadip_map_mission
 from rs_server_common.data_retrieval.provider import CreateProviderFailed, Provider
+from rs_server_common.utils.utils2 import read_response_error
 
 from tests.app import ROUTER_PREFIX_AUXIP, ROUTER_PREFIX_CADIP
 
@@ -871,14 +872,17 @@ class TestFeatureCollectionOdataStacMapping:
         """Test endpoint call with invalid bbox (brackets, wrong coordinates count)"""
         response = client.get(endpoint)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["detail"] in (
+        error: str = read_response_error(response)
+        assert error, response.json()
+        assert error.replace("400: ", "") in (
             "could not convert string to float: '[100.0'",
+            "invalid bbox: [100.0, 0.0, 105.0, 1.0]",
             "BBox '0' must have 4 or 6 values.",
             "BBox '0,0' must have 4 or 6 values.",
             "BBox '0,0,0' must have 4 or 6 values.",
             "BBox '0,0,0,1,1' must have 4 or 6 values.",
             "BBox '0,0,0,1,1,1,1' must have 4 or 6 values.",
-        ), response.json()["detail"]
+        ), error
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -903,14 +907,17 @@ class TestFeatureCollectionOdataStacMapping:
         """Test endpoint call with invalid bbox (brackets, wrong coordinates count)"""
         response = client.get(endpoint)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["description"] in (
+        error = read_response_error(response)
+        assert error, response.json()
+        assert error.replace("400: ", "") in (
             "could not convert string to float: '[100.0'",
+            "invalid bbox: [100.0, 0.0, 105.0, 1.0]",
             "BBox '0' must have 4 or 6 values.",
             "BBox '0,0' must have 4 or 6 values.",
             "BBox '0,0,0' must have 4 or 6 values.",
             "BBox '0,0,0,1,1' must have 4 or 6 values.",
             "BBox '0,0,0,1,1,1,1' must have 4 or 6 values.",
-        ), response.json()["description"]
+        ), error
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -1515,7 +1522,7 @@ def test_search_parameters(
         raise NotImplementedError
 
     # Read the first adgs or cadip collection, keep everything except the id and hardcoded query
-    collection = service_utils.read_conf()["collections"][0]
+    collection: dict = service_utils.read_conf()["collections"][0]
     collection = deepcopy(collection)  # copy the cached response before we modify it
     collection.pop("id")
     collection.pop("query")
@@ -1684,7 +1691,7 @@ def test_search_parameters(
             # if the reponse is not mocked.
             # Decode the query (for better readability) using: https://meyerweb.com/eric/tools/dencoder/
             # TODO after fixing rs-server, these parameters should appear in the OData request:
-            #  - sortBy (https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-131)
+            #  - sortBy (RSPY-131)
 
             if adgs:
                 uid = user_ids.split(",", maxsplit=1)[0]
@@ -1716,7 +1723,6 @@ def test_search_parameters(
                     "and (PublicationDate lt {date_max} or PublicationDate eq {date_max})"
                     "&$orderby=PublicationDate%20asc&$top=15&$skip=0"
                 )
-
                 odata_query = (
                     "http://127.0.0.1:5000/Sessions?$filter="
                     f"SessionId in ({user_ids_with_quote}) "
@@ -1834,7 +1840,7 @@ def test_search_parameters(
                     raise NotImplementedError
 
                 # Check that the search function was called and returned the expected result
-                assert response.is_success
+                assert response.is_success, f"Response:{response}\nMock registered responses:{rsps.registered()}"
                 features = response.json()["features"]
                 if expect_result and adgs:
                     # 2 calls, one for sessions, one for files
@@ -1894,8 +1900,8 @@ def test_search_all_collections(
         response = client.get(url)
 
         # We have mocked the same response for all n collections,
-        # so we should have n calls to the search function a single result.
+        # so we should have a single result and a single call since RSPY-706
         assert response.is_success
         features = response.json()["features"]
-        assert spy_search.call_count == collection_count
+        assert spy_search.call_count == 1
         assert len(spy_search.spy_return) == len(features) == 1


### PR DESCRIPTION
https://github.com/RS-PYTHON/rs-server/pull/1334
https://github.com/RS-PYTHON/rs-helm/pull/134
https://github.com/RS-PYTHON/rs-demo/pull/153

New STAC search algorithm:

- if collection ids are given in the search request:

1. build the list of stations for the given collections (ex: adgs, adgs2)

1. for each station, perform ONE request that combines the different criteria defined for each collection of this station also given in the request

- if no collection is given:

1. for each station, perform ONE request that takes only the criteria sent in the search request

1. for each returned item, try to guess the collection based on the criteria defined for each collection of the station (if only one collection matches, use it. If not exactly one, log a warning and do not return the item as it could bypass the authorization per collection)
