### PR TITLE
Fix SARIF upload category

### DIFF
--- a/.github/actions/publish-docker/action.yml
+++ b/.github/actions/publish-docker/action.yml
@@ -155,7 +155,7 @@ runs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: trivy-results-docker.sarif
-        category: ${{ env.docker_image }}
+        category: ${{ inputs.image_basename }}${{ inputs.image_suffix }}
 
     - name: Display link to Trivy results
       run: |


### PR DESCRIPTION
Hello from GitHub Code Scanning! 😄👋

We noticed your repo had an unusually large number of active categories for the default branch, which I think was unintended.

Including the docker image version name in the category will create a distinct category for each scan
This means you won't be able to track alert changes between two different runs of the same tool.
Similarly, if an alert is fixed in recent runs, it will continue to appear as open because it's still present in all the other scan categories.

It also causes an exponential increase in the number of open alerts, which makes Code Scanning practically unusable. 

--- 

This PR changes changes the category format from e.g. `ghcr.io/rs-python/rs-server-frontend:0.2a14.post47.dev0` to `rs-python/rs-server-frontend`.

Unfortunately, you'll still be stuck with all the old categories unless you manually delete them via the API.
If it makes things easier, we can clean them up for you. We can either wipe out all the history so you have a clean slate, or target on the misconfigured Trivy categories.