### PR TITLE
RSPY-726 - AUXIP: fix retrieval of collection for those defined with a constellation

### DIFF
--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -75,7 +75,7 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 SEARCH_LIMIT = 10000  # max number of products returned by eodag
 
 DATE_INTERVAL_KEYS = ["PublicationDate"]
-COMMA_SEPARATED_LISTS_KEYS = ["platformSerialIdentifier", "platformShortName", "Satellite", "productType"]
+COMMA_SEPARATED_LISTS_KEYS = ["platformSerialIdentifier", "platformShortName", "Satellite", "productType", "SessionId"]
 
 # Type hints
 CollectionType = Annotated[str, FPath(description="Collection ID", max_length=100)]
@@ -714,7 +714,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                     match(odata_entity, "date", crit_key, crit_val)
                 elif crit_key in COMMA_SEPARATED_LISTS_KEYS:
                     iterable = crit_val if isinstance(crit_val, list) else crit_val.split(",")
-                    if value not in {v.strip() for v in iterable}:
+                    if value is None or value.strip().lower() not in {v.strip().lower() for v in iterable}:
                         return nomatch(odata_entity, "list", crit_key, crit_val)
                     match(odata_entity, "list", crit_key, crit_val)
                 elif crit_val != odata_entity.get(crit_key, None):
@@ -730,9 +730,14 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
         Args:
             items (list[Item]): The list of items to filter (modified in place).
         """
-        items[:] = [
-            item for item in items if item.collection or not logger.warning(f"Filter item without collection: {item}")
-        ]
+
+        def has_collection(item):
+            if not item.collection:
+                logger.warning(f"Filter item without collection: {item}")
+                return False
+            return True
+
+        items[:] = [item for item in items if has_collection(item)]
 
     def aggregate_items_from_results(self, all_results) -> ItemCollection:
         """

--- a/services/common/rs_server_common/utils/utils.py
+++ b/services/common/rs_server_common/utils/utils.py
@@ -207,6 +207,8 @@ def odata_to_stac(
     # determine item collection
     if collection_provider:
         feature_template["collection"] = collection_provider(odata_dict)
+        if not feature_template["collection"]:
+            logger.warning(f"Unable to determine collection for {odata_dict}")
     return feature_template
 
 

--- a/tests/resources/endpoints/cadip_search.yaml
+++ b/tests/resources/endpoints/cadip_search.yaml
@@ -50,6 +50,36 @@ collections:
         url: 'https://home.rs-python.eu/'
 
 
+  - id: cadip_session_by_id_list_big
+    station: cadip
+    query:
+      SessionId: S1A_20200105072204051312,S1A_20200105072204051313,S1A_20200105072204051314,S1A_20200105072204051315,S1A_20200105072204051316,S1A_20200105072204051317,S1A_20200105072204051318,S1A_20200105072204051319,S1A_20200105072204051310,S1A_20200105072204051311
+      top: 20
+    stac_extensions: [ "https://stac-extensions.github.io/eo/v1.0.0/schema.json", "https://stac-extensions.github.io/projection/v1.0.0/schema.json", "https://stac-extensions.github.io/view/v1.0.0/schema.json" ]
+    title: 'Test collection'
+    description: 'Sentinel-1 test CADIP sessions'
+    license: other
+    extent:
+      spatial:
+        bbox: [[ -180, -82.85, 180, 82.82 ]]
+      temporal:
+        interval: [[ '2024-06-12T02:57:21.459000Z', '2024-08-22T11:30:12.767000Z' ]]
+    links:
+      - rel: license
+        href: 'https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf'
+        title: 'Legal notice on the use of Copernicus Sentinel Data and Service Information'
+    providers:
+      - name: 'European Union/ESA/Copernicus'
+        roles:
+          - producer
+          - licensor
+        url: 'https://sentiwiki.copernicus.eu/web/s1-mission'
+      - name: 'Reference System'
+        roles:
+          - host
+        url: 'https://home.rs-python.eu/'
+
+
   - id: cadip_session_by_id
     station: cadip
     query:
@@ -78,14 +108,14 @@ collections:
         roles:
           - host
         url: 'https://home.rs-python.eu/'
+
+
   - id: cadip_session_by_id_platform
     station: cadip
     query:
       SessionId: S1A_20240328185208053186
       Satellite: S1A
       top: 20
-
-
     stac_extensions: [ "https://stac-extensions.github.io/eo/v1.0.0/schema.json", "https://stac-extensions.github.io/projection/v1.0.0/schema.json", "https://stac-extensions.github.io/view/v1.0.0/schema.json" ]
     title: 'Test collection'
     description: 'Sentinel-1 test CADIP sessions'
@@ -171,6 +201,7 @@ collections:
           - host
         url: 'https://home.rs-python.eu/'
 
+
   - id: cadip_session_by_start_stop_platform
     station: cadip
     query:
@@ -232,7 +263,6 @@ collections:
         url: 'https://home.rs-python.eu/'
 
 
-
   - id: cadip_session_by_satellite
     station: cadip
     query:
@@ -291,6 +321,7 @@ collections:
         roles:
           - host
         url: 'https://home.rs-python.eu/'
+
 
   - id: cadip_session_incorrect
     station: cadip
@@ -489,6 +520,7 @@ collections:
         roles:
           - host
         url: 'https://home.rs-python.eu/'
+
 
   - id: test_collection
     station: authTest

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -318,7 +318,7 @@ class TestModelValidationError:
         [
             (ROUTER_PREFIX_CADIP, "/cadip/search?collections=cadip_session_by_id_list"),
             (ROUTER_PREFIX_CADIP, "/cadip/collections/cadip_session_by_id_list/items"),
-            (ROUTER_PREFIX_CADIP, "/cadip/collections/cadip_session_by_id_list/items/sessionId"),
+            (ROUTER_PREFIX_CADIP, "/cadip/collections/cadip_session_by_id_list/items/S1A_20170501121534062343"),
         ],
         indirect=["fastapi_app"],
     )
@@ -1315,8 +1315,8 @@ class TestFeatureCollectionOdataStacMapping:
         [
             ("/auxip/collections/s2_adgs2_AUX_OBMEMC/items?token=next:page=", "3", True),
             ("/auxip/collections/s2_adgs2_AUX_OBMEMC/items?token=next:page=", "1", False),
-            ("/cadip/collections/cadip_session_by_id/items?token=next:page=", "3", True),
-            ("/cadip/collections/cadip_session_by_id/items?token=next:page=", "1", False),
+            ("/cadip/collections/cadip_session_by_id_list_big/items?token=next:page=", "3", True),
+            ("/cadip/collections/cadip_session_by_id_list_big/items?token=next:page=", "1", False),
         ],
     )
     @responses.activate
@@ -1331,13 +1331,24 @@ class TestFeatureCollectionOdataStacMapping:
     ):
         """Used to test if application correctly builds next/previous token."""
         base_cadip_uri = (
-            "http://127.0.0.1:5000/Sessions?$filter=SessionId eq 'S1A_20200105072204051312'"
-            "&$orderby=PublicationDate desc&"
+            "http://127.0.0.1:5000/Sessions?$filter=SessionId in ("
+            "'S1A_20200105072204051312', 'S1A_20200105072204051313', 'S1A_20200105072204051314', "
+            "'S1A_20200105072204051315', 'S1A_20200105072204051316', 'S1A_20200105072204051317', "
+            "'S1A_20200105072204051318', 'S1A_20200105072204051319', 'S1A_20200105072204051310', "
+            "'S1A_20200105072204051311')&$orderby=PublicationDate desc&"
             f"$top=10&$skip={(int(page) - 1) * 10}"
         )
-        base_cadip_files_uri = (
-            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051312'&$top=1000&$skip=0"
-        )
+        base_cadip_files_uris = [
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051312'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051313'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051314'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051315'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051316'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051317'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051318'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051319'&$top=1000&$skip=0",
+            "http://127.0.0.1:5000/Files?$filter=SessionId eq 'S1A_20200105072204051311'&$top=1000&$skip=0",
+        ]
         base_adgs_uri = (
             "http://127.0.0.1:5001/Products?"
             "$filter=Attributes/OData.CSC.StringAttribute/any(att:att/Name%20eq%20'productType'%20and%20"
@@ -1352,7 +1363,8 @@ class TestFeatureCollectionOdataStacMapping:
             json={"value": []} if is_last else cadip_session_response_10_items,
             status=200,
         )
-        responses.add(responses.GET, base_cadip_files_uri, json={"value": []}, status=200)
+        for base_cadip_files_uri in base_cadip_files_uris:
+            responses.add(responses.GET, base_cadip_files_uri, json={"value": []}, status=200)
         responses.add(
             responses.GET,
             base_adgs_uri,
@@ -1535,11 +1547,11 @@ def test_search_parameters(
 
     if adgs:
         query2 = {
-            "productType": "type1",
+            "productType": "AUX_OBMEMC",
             "platformShortName": "sentinel-1",
         }
         query3 = {
-            "productType": "type1, type2",
+            "productType": "AUX_OBMEMC, type2",
             "platformShortName": "sentinel-1, sentinel-2",
         }
     elif cadip:


### PR DESCRIPTION
AUXIP makes use both of lowercase and uppercase for the constellation, depending on product type. Make sure the comparison is always lowercase.