### PR TITLE
Fix/RSPY-709: Support refresh token without "refresh_expires_in" field

### DIFF
--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -58,6 +58,11 @@ MANDATORY_TOKEN_ATTRS = [
     "expires_in",
     "refresh_token",
     "refresh_token_creation_date",
+]
+
+# Token attributes that are not mandatory but are expected to be present
+# in a regular token.
+EXPECTED_TOKEN_ATTRS = [
     "refresh_expires_in",
 ]
 
@@ -173,6 +178,15 @@ def validate_token_dict(token_dict: Any, config: StationExternalAuthenticationCo
                 None,
                 TokenDataNotFound,
             )
+    for attr in EXPECTED_TOKEN_ATTRS:
+        if attr not in token_dict:
+            logger.warning(
+                f"Attribute {attr} is not defined in the token variable " f"of the station {config.station_id}.",
+            )
+        if not token_dict[attr]:
+            logger.warning(
+                f"Token variable attribute {attr} of the station {config.station_id} is None.",
+            )
     for attr in "access_token", "refresh_token":
         validate_token_format(attr)
 
@@ -263,12 +277,21 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
 
     # If we have no token yet or if both the access and refresh tokens are expired, we get a new token
     # using the authorisation grant
-    if not token_dict or (
-        token_dict
-        and (current_date - token_dict["access_token_creation_date"]).total_seconds()
-        > token_dict["expires_in"] - nb_secs_before_token_exp
-        and (current_date - token_dict["refresh_token_creation_date"]).total_seconds()
-        > token_dict["refresh_expires_in"] - nb_secs_before_refresh_token_exp
+    if (
+        not token_dict
+        or (
+            token_dict
+            and ("refresh_expires_in" not in token_dict.keys() or not token_dict["refresh_expires_in"])
+            and (current_date - token_dict["access_token_creation_date"]).total_seconds()
+            > token_dict["expires_in"] - nb_secs_before_token_exp
+        )
+        or (
+            token_dict
+            and (current_date - token_dict["access_token_creation_date"]).total_seconds()
+            > token_dict["expires_in"] - nb_secs_before_token_exp
+            and (current_date - token_dict["refresh_token_creation_date"]).total_seconds()
+            > token_dict["refresh_expires_in"] - nb_secs_before_refresh_token_exp
+        )
     ):
         if not token_dict:
             logger.info(

--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -279,7 +279,7 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
     # or if both the access and refresh tokens are expired,
     # or if we don't have any 'refresh_expires_in' value but the access token is expired,
     # we get a new token using the authorisation grant
-    if (
+    if (  # pylint: disable=too-many-boolean-expressions
         not token_dict
         or (
             token_dict
@@ -294,7 +294,7 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
             and (current_date - token_dict["refresh_token_creation_date"]).total_seconds()
             > token_dict["refresh_expires_in"] - nb_secs_before_refresh_token_exp
         )
-    ):  # pylint: disable=too-many-boolean-expressions
+    ):
         if not token_dict:
             logger.info(
                 f"""No existing token found -> fetching a new access token """

--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -275,36 +275,43 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
     nb_secs_before_token_exp = int(os.getenv("RSPY_TIME_BEFORE_ACCESS_TOKEN_EXPIRE", "60"))
     nb_secs_before_refresh_token_exp = int(os.getenv("RSPY_TIME_BEFORE_REFRESH_TOKEN_EXPIRE", "60"))
 
-    # Cases when we need a new token:
-    # - if we have no token yet
-    # - if both the access and refresh tokens are expired
-    # - if we don't have any 'refresh_expires_in' value but the access token is expired
-    get_new_token = False
+    # If we have no token yet, then we need one
     if not token_dict:
-        get_new_token = True
+        get_token = True
         logger.info(
             f"""No existing token found -> fetching a new access token """
             f"""from station url: {external_auth_config.token_url}""",
         )
-    else:
-        is_access_token_expired = (
-            current_date - token_dict["access_token_creation_date"]
-        ).total_seconds() > token_dict["expires_in"] - nb_secs_before_token_exp
-        is_refresh_token_expired = (
-            "refresh_expires_in" not in token_dict.keys() or not token_dict["refresh_expires_in"]
-        ) or (current_date - token_dict["refresh_token_creation_date"]).total_seconds() > token_dict[
-            "refresh_expires_in"
-        ] - nb_secs_before_refresh_token_exp
 
-        if is_access_token_expired and is_refresh_token_expired:
-            get_new_token = True
+    # Else, check if the access token is expired
+    else:
+        access_age = (current_date - token_dict["access_token_creation_date"]).total_seconds()
+        access_age += nb_secs_before_token_exp  # take a margin
+
+        # We don't need a new token if the access token is young enough
+        if access_age <= token_dict["expires_in"]:
+            get_token = False
+
+        # If the access token is too old, we also check the refresh token
+        else:
+            # If it's missing, then we need a new token
+            if "refresh_expires_in" not in token_dict:
+                get_token = True
+
+            # Else we need a new token if the access and refresh token are both too old
+            else:
+                refresh_age = (current_date - token_dict["refresh_token_creation_date"]).total_seconds()
+                refresh_age += nb_secs_before_refresh_token_exp  # take a margin
+                get_token = refresh_age > token_dict["refresh_expires_in"]
+
+        if get_token:
             logger.info(
                 f"""Current access and refresh token expired -> fetching access token """
                 f"""from station url: {external_auth_config.token_url}""",
             )
 
     # If necessary, get a new token using the authorisation grant
-    if get_new_token:
+    if get_token:
         # Get the new token and add its creation date
         data_to_send = prepare_data(external_auth_config, call_refresh=False)
         token_dict.update(__request_token(external_auth_config, data_to_send))

--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -60,12 +60,6 @@ MANDATORY_TOKEN_ATTRS = [
     "refresh_token_creation_date",
 ]
 
-# Token attributes that are not mandatory but are expected to be present
-# in a regular token.
-OPTIONAL_TOKEN_ATTRS = [
-    "refresh_expires_in",
-]
-
 
 class TokenDataNotFound(HTTPException):
     """Raised if there are missing data in the dictionary to handle information about the token"""
@@ -177,15 +171,6 @@ def validate_token_dict(token_dict: Any, config: StationExternalAuthenticationCo
                 f"Token variable attribute {attr} of the station {config.station_id} is None !",
                 None,
                 TokenDataNotFound,
-            )
-    for attr in OPTIONAL_TOKEN_ATTRS:
-        if attr not in token_dict:
-            logger.warning(
-                f"Attribute {attr} is not defined in the token variable " f"of the station {config.station_id}.",
-            )
-        if not token_dict[attr]:
-            logger.warning(
-                f"Token variable attribute {attr} of the station {config.station_id} is None.",
             )
     for attr in "access_token", "refresh_token":
         validate_token_format(attr)

--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -275,8 +275,10 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
     nb_secs_before_token_exp = int(os.getenv("RSPY_TIME_BEFORE_ACCESS_TOKEN_EXPIRE", "60"))
     nb_secs_before_refresh_token_exp = int(os.getenv("RSPY_TIME_BEFORE_REFRESH_TOKEN_EXPIRE", "60"))
 
-    # If we have no token yet or if both the access and refresh tokens are expired, we get a new token
-    # using the authorisation grant
+    # If we have no token yet
+    # or if both the access and refresh tokens are expired,
+    # or if we don't have any 'refresh_expires_in' value but the access token is expired,
+    # we get a new token using the authorisation grant
     if (
         not token_dict
         or (
@@ -292,7 +294,7 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
             and (current_date - token_dict["refresh_token_creation_date"]).total_seconds()
             > token_dict["refresh_expires_in"] - nb_secs_before_refresh_token_exp
         )
-    ):
+    ):  # pylint: disable=too-many-boolean-expressions
         if not token_dict:
             logger.info(
                 f"""No existing token found -> fetching a new access token """

--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -62,7 +62,7 @@ MANDATORY_TOKEN_ATTRS = [
 
 # Token attributes that are not mandatory but are expected to be present
 # in a regular token.
-EXPECTED_TOKEN_ATTRS = [
+OPTIONAL_TOKEN_ATTRS = [
     "refresh_expires_in",
 ]
 
@@ -178,7 +178,7 @@ def validate_token_dict(token_dict: Any, config: StationExternalAuthenticationCo
                 None,
                 TokenDataNotFound,
             )
-    for attr in EXPECTED_TOKEN_ATTRS:
+    for attr in OPTIONAL_TOKEN_ATTRS:
         if attr not in token_dict:
             logger.warning(
                 f"Attribute {attr} is not defined in the token variable " f"of the station {config.station_id}.",

--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -275,37 +275,36 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
     nb_secs_before_token_exp = int(os.getenv("RSPY_TIME_BEFORE_ACCESS_TOKEN_EXPIRE", "60"))
     nb_secs_before_refresh_token_exp = int(os.getenv("RSPY_TIME_BEFORE_REFRESH_TOKEN_EXPIRE", "60"))
 
-    # If we have no token yet
-    # or if both the access and refresh tokens are expired,
-    # or if we don't have any 'refresh_expires_in' value but the access token is expired,
-    # we get a new token using the authorisation grant
-    if (  # pylint: disable=too-many-boolean-expressions
-        not token_dict
-        or (
-            token_dict
-            and ("refresh_expires_in" not in token_dict.keys() or not token_dict["refresh_expires_in"])
-            and (current_date - token_dict["access_token_creation_date"]).total_seconds()
-            > token_dict["expires_in"] - nb_secs_before_token_exp
+    # Cases when we need a new token:
+    # - if we have no token yet
+    # - if both the access and refresh tokens are expired
+    # - if we don't have any 'refresh_expires_in' value but the access token is expired
+    get_new_token = False
+    if not token_dict:
+        get_new_token = True
+        logger.info(
+            f"""No existing token found -> fetching a new access token """
+            f"""from station url: {external_auth_config.token_url}""",
         )
-        or (
-            token_dict
-            and (current_date - token_dict["access_token_creation_date"]).total_seconds()
-            > token_dict["expires_in"] - nb_secs_before_token_exp
-            and (current_date - token_dict["refresh_token_creation_date"]).total_seconds()
-            > token_dict["refresh_expires_in"] - nb_secs_before_refresh_token_exp
-        )
-    ):
-        if not token_dict:
-            logger.info(
-                f"""No existing token found -> fetching a new access token """
-                f"""from station url: {external_auth_config.token_url}""",
-            )
-        else:
+    else:
+        is_access_token_expired = (
+            current_date - token_dict["access_token_creation_date"]
+        ).total_seconds() > token_dict["expires_in"] - nb_secs_before_token_exp
+        is_refresh_token_expired = (
+            "refresh_expires_in" not in token_dict.keys() or not token_dict["refresh_expires_in"]
+        ) or (current_date - token_dict["refresh_token_creation_date"]).total_seconds() > token_dict[
+            "refresh_expires_in"
+        ] - nb_secs_before_refresh_token_exp
+
+        if is_access_token_expired and is_refresh_token_expired:
+            get_new_token = True
             logger.info(
                 f"""Current access and refresh token expired -> fetching access token """
                 f"""from station url: {external_auth_config.token_url}""",
             )
 
+    # If necessary, get a new token using the authorisation grant
+    if get_new_token:
         # Get the new token and add its creation date
         data_to_send = prepare_data(external_auth_config, call_refresh=False)
         token_dict.update(__request_token(external_auth_config, data_to_send))

--- a/services/common/rs_server_common/authentication/token_auth.py
+++ b/services/common/rs_server_common/authentication/token_auth.py
@@ -287,14 +287,22 @@ def get_station_token(external_auth_config: StationExternalAuthenticationConfig,
             f"""from station url: {external_auth_config.token_url}""",
         )
     else:
-        is_access_token_expired = (
-            current_date - token_dict["access_token_creation_date"]
-        ).total_seconds() > token_dict["expires_in"] - nb_secs_before_token_exp
-        is_refresh_token_expired = (
-            "refresh_expires_in" not in token_dict.keys() or not token_dict["refresh_expires_in"]
-        ) or (current_date - token_dict["refresh_token_creation_date"]).total_seconds() > token_dict[
-            "refresh_expires_in"
-        ] - nb_secs_before_refresh_token_exp
+        access_token_expiration_date = (
+            token_dict["access_token_creation_date"].total_seconds()
+            + token_dict["expires_in"]
+            - nb_secs_before_token_exp
+        )
+        is_access_token_expired = current_date > access_token_expiration_date
+
+        if "refresh_expires_in" not in token_dict.keys() or not token_dict["refresh_expires_in"]:
+            is_refresh_token_expired = True
+        else:
+            refresh_token_expiration_date = (
+                token_dict["refresh_token_creation_date"].total_seconds()
+                + token_dict["refresh_expires_in"]
+                - nb_secs_before_refresh_token_exp
+            )
+            is_refresh_token_expired = current_date > refresh_token_expiration_date
 
         if is_access_token_expired and is_refresh_token_expired:
             get_new_token = True

--- a/tests/test_authentication_to_external.py
+++ b/tests/test_authentication_to_external.py
@@ -186,6 +186,31 @@ def test_get_station_token(get_external_auth_config, mock_token_dict):
     # Check that the old token has been replaced with the new one
     assert new_token["refresh_token"] == response_new_valid_token["refresh_token"]
 
+    # ---------- Test to generate a new token when current access token is expired
+    # and there is no refresh_expires_in value
+
+    # Change the mock variable creation date and expiration date of both access and refresh tokens
+    # to make them become unvalid
+    mock_token_dict["access_token_creation_date"] = datetime.datetime(2023, 8, 15, 14, 30, 45)
+    mock_token_dict["refresh_token_creation_date"] = datetime.datetime(2023, 8, 15, 14, 30, 45)
+
+    response_new_valid_token = {
+        "access_token": "NewFakeAccessToken",
+        "expires_in": 3600,
+        "refresh_token": "NewfakeRefreshToken",
+        "token_type": "Bearer",
+    }
+    responses.add(
+        responses.POST,
+        url=ext_auth_config.token_url,
+        status=HTTP_200_OK,
+        body=json.dumps(response_new_valid_token),
+    )
+    new_token = get_station_token(ext_auth_config, mock_token_dict)
+    # Check that the old token has been replaced with the new one
+    assert new_token["access_token"] == response_new_valid_token["access_token"]
+    assert new_token["refresh_token"] == response_new_valid_token["refresh_token"]
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize("station_id", ["adgs", "ins"])


### PR DESCRIPTION
Changed token_auth to make refresh_expires_in field not mandatory. In the case when refresh_expires_in is not present, the access_token will be refreshed only using the field "expires_in" but the refresh_token will be refreshed at the same time.

Fix for: https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-709