### PR TITLE
feat-615/child-link-in-stac-landing-pages

### DIFF
--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -930,7 +930,7 @@ field is not permitted also."
             # add child links
             collections_resp = await self.client.all_collections(request=request)
             collections = collections_resp.get("collections", [])
-            base_url = content["links"][0]["href"].rstrip("/") + "/"
+            base_url = next((l["href"] for l in content["links"] if l.get("rel") == "self"), "").rstrip("/") + "/"
 
             for collection in collections:
                 collection_id = (
@@ -943,7 +943,7 @@ field is not permitted also."
                         "rel": "child",
                         "type": "application/json",
                         "title": collection.get("title") or collection_id,
-                        "href": urljoin(base_url, f"collections/{collection_id}"),
+                        "href": urljoin(base_url, f"collections/{collection['owner']}:{collection_id}"),
                     },
                 )
 

--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -950,7 +950,9 @@ field is not permitted also."
             # add child links
             collections_resp = await self.client.all_collections(request=request)
             collections = collections_resp.get("collections", [])
-            base_url = next((l["href"] for l in content["links"] if l.get("rel") == "self"), "").rstrip("/") + "/"
+            base_url = (
+                next((link["href"] for link in content["links"] if link.get("rel") == "self"), "").rstrip("/") + "/"
+            )
 
             for collection in collections:
                 collection_id = (

--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -34,7 +34,7 @@ import json
 import os
 import re
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
 import botocore
 from fastapi import HTTPException
@@ -926,6 +926,26 @@ field is not permitted also."
             url = request.url._url  # pylint: disable=protected-access
             url = url[: len(url) - len(request.url.path)]
             content = add_prefix_link_landing_page(content, url)
+
+            # add child links
+            collections_resp = await self.client.all_collections(request=request)
+            collections = collections_resp.get("collections", [])
+            base_url = content["links"][0]["href"].rstrip("/") + "/"
+
+            for collection in collections:
+                collection_id = (
+                    collection["id"].removeprefix(f"{collection['owner']}_")
+                    if collection["owner"]
+                    else collection["id"]
+                )
+                content["links"].append(
+                    {
+                        "rel": "child",
+                        "type": "application/json",
+                        "title": collection.get("title") or collection_id,
+                        "href": urljoin(base_url, f"collections/{collection_id}"),
+                    },
+                )
 
         elif request.scope["path"] == "/collections":  # /catalog/owner_id/collections
             if self.request_ids["owner_id"]:

--- a/services/catalog/rs_server_catalog/user_catalog.py
+++ b/services/catalog/rs_server_catalog/user_catalog.py
@@ -947,7 +947,7 @@ field is not permitted also."
             url = url[: len(url) - len(request.url.path)]
             content = add_prefix_link_landing_page(content, url)
 
-            # add child links
+            # patch the catalog landing page with "rel": "child" link for each collection
             collections_resp = await self.client.all_collections(request=request)
             collections = collections_resp.get("collections", [])
             base_url = (

--- a/services/catalog/tests/test_authentication_catalog.py
+++ b/services/catalog/tests/test_authentication_catalog.py
@@ -17,6 +17,7 @@
 """Unit tests for the authentication."""
 
 import json
+import os
 
 import pytest
 import requests
@@ -178,6 +179,48 @@ async def test_authentication_and_contents(mocker, httpx_mock: HTTPXMock, client
             "type": "text/html",
             "title": "OpenAPI service documentation",
             "href": "http://testserver/catalog/api.html",
+            **AUTHENT_REF,
+        },
+        {
+            "rel": "child",
+            "type": "application/json",
+            "title": "S1_L1",
+            "href": "http://testserver/catalog/collections/toto:S1_L1",
+            **AUTHENT_REF,
+        },
+        {
+            "rel": "child",
+            "type": "application/json",
+            "title": "S2_L3",
+            "href": "http://testserver/catalog/collections/toto:S2_L3",
+            **AUTHENT_REF,
+        },
+        {
+            "rel": "child",
+            "type": "application/json",
+            "title": "S2_L1",
+            "href": "http://testserver/catalog/collections/titi:S2_L1",
+            **AUTHENT_REF,
+        },
+        {
+            "rel": "child",
+            "type": "application/json",
+            "title": "S1_L2",
+            "href": "http://testserver/catalog/collections/darius:S1_L2",
+            **AUTHENT_REF,
+        },
+        {
+            "rel": "child",
+            "type": "application/json",
+            "title": "S1_L1",
+            "href": "http://testserver/catalog/collections/pyteam:S1_L1",
+            **AUTHENT_REF,
+        },
+        {
+            "rel": "child",
+            "type": "application/json",
+            "title": "S2_L2",
+            "href": f"http://testserver/catalog/collections/{os.environ['LOGNAME']}:S2_L2",
             **AUTHENT_REF,
         },
     ]

--- a/services/common/rs_server_common/fastapi_app.py
+++ b/services/common/rs_server_common/fastapi_app.py
@@ -137,7 +137,7 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
         original = await CoreCrudClient.landing_page(self, request=request, **kwargs)
 
         # Get base from 'self' link
-        base = next((l["href"] for l in original["links"] if l.get("rel") == "self"), "").rstrip("/") + "/"
+        base = next((link["href"] for link in original["links"] if link.get("rel") == "self"), "").rstrip("/") + "/"
 
         # Fetch collections
         collections = (await self.all_collections(request=request)).get("collections", [])

--- a/services/common/rs_server_common/fastapi_app.py
+++ b/services/common/rs_server_common/fastapi_app.py
@@ -17,6 +17,8 @@
 import typing
 from contextlib import asynccontextmanager
 from os import environ as env
+from types import MethodType
+from urllib.parse import urljoin
 
 import httpx
 from fastapi import APIRouter, Depends, FastAPI, Request
@@ -128,6 +130,35 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
     ]
     search_post_request_model = create_post_request_model(extensions, base_model=PgstacSearch)
     app.state.pgstac_client = CoreCrudClient(pgstac_search_model=search_post_request_model)
+
+    # Store the bound method correctly
+    original_landing_page = app.state.pgstac_client.landing_page
+
+    async def patched_landing_page(self, request, **kwargs):
+        # Call the original method
+        original = await original_landing_page(request=request, **kwargs)
+
+        # Get base from 'self' link
+        base = next((l["href"] for l in original["links"] if l.get("rel") == "self"), "").rstrip("/") + "/"
+
+        # Fetch collections
+        collections = (await self.all_collections(request=request)).get("collections", [])
+
+        # Append rel="child" links
+        original["links"] += [
+            {
+                "rel": "child",
+                "type": "application/json",
+                "title": collection.get("title") or collection["id"],
+                "href": urljoin(base, f"collections/{collection['id']}"),
+            }
+            for collection in collections
+        ]
+
+        return original
+
+    # Monkey patch the pgstac_client.landing_page method
+    app.state.pgstac_client.landing_page = MethodType(patched_landing_page, app.state.pgstac_client)
 
     # TODO: remove this when adgs and cadip switch to a stac_fastapi application.
     app.state.pgstac_client.extensions = extensions

--- a/services/common/rs_server_common/fastapi_app.py
+++ b/services/common/rs_server_common/fastapi_app.py
@@ -131,12 +131,10 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
     search_post_request_model = create_post_request_model(extensions, base_model=PgstacSearch)
     app.state.pgstac_client = CoreCrudClient(pgstac_search_model=search_post_request_model)
 
-    # Store the bound method correctly
-    original_landing_page = app.state.pgstac_client.landing_page
-
+    # patch the pgstac_client.landing_page method
     async def patched_landing_page(self, request, **kwargs):
         # Call the original method
-        original = await original_landing_page(request=request, **kwargs)
+        original = await CoreCrudClient.landing_page(self, request=request, **kwargs)
 
         # Get base from 'self' link
         base = next((l["href"] for l in original["links"] if l.get("rel") == "self"), "").rstrip("/") + "/"

--- a/services/common/rs_server_common/fastapi_app.py
+++ b/services/common/rs_server_common/fastapi_app.py
@@ -131,7 +131,7 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
     search_post_request_model = create_post_request_model(extensions, base_model=PgstacSearch)
     app.state.pgstac_client = CoreCrudClient(pgstac_search_model=search_post_request_model)
 
-    # patch the pgstac_client.landing_page method
+    # patch the pgstac_client.landing_page method to add "rel": "child" link for each collection
     async def patched_landing_page(self, request, **kwargs):
         # Call the original method
         original = await CoreCrudClient.landing_page(self, request=request, **kwargs)


### PR DESCRIPTION
Conformance of STAC landing pages to ESA requirements as per 
https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-615

Add "child" links to collections for CADIP, AUXIP and Catalog landing pages
