### PR TITLE
RSPY-784 - Define openapi links in STAC fastapi applications

### DIFF
--- a/services/common/rs_server_common/fastapi_app.py
+++ b/services/common/rs_server_common/fastapi_app.py
@@ -16,12 +16,11 @@
 
 import typing
 from contextlib import asynccontextmanager
-from os import environ as env
 from types import MethodType
 from urllib.parse import urljoin
 
 import httpx
-from fastapi import APIRouter, Depends, FastAPI, Request
+from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from httpx._config import DEFAULT_TIMEOUT_CONFIG
@@ -31,11 +30,13 @@ from rs_server_common.authentication.authentication import authenticate
 from rs_server_common.authentication.oauth2 import AUTH_PREFIX
 from rs_server_common.middlewares import HandleExceptionsMiddleware
 from rs_server_common.schemas.health_schema import HealthSchema
+from rs_server_common.settings import docs_params
 from rs_server_common.utils import init_opentelemetry
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.errors import add_exception_handlers
 from stac_fastapi.api.middleware import ProxyHeaderMiddleware
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
+from stac_fastapi.api.openapi import update_openapi
 from stac_fastapi.api.routes import add_route_dependencies
 from stac_fastapi.extensions.core import (
     FieldsExtension,
@@ -101,16 +102,8 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
         # Close objects for dependency injection
         await settings.del_http_client()
 
-    # For cluster deployment: override the swagger /docs URL from an environment variable.
-    # Also set the openapi.json URL under the same path.
-    try:
-        docs_url = env["RSPY_DOCS_URL"].strip("/")
-        docs_params = {"docs_url": f"/{docs_url}", "openapi_url": f"/{docs_url}/openapi.json"}
-    except KeyError:
-        docs_params = {}
-
     # Init the FastAPI application
-    app = FastAPI(title="RS-Server", version=api_version, lifespan=lifespan, **docs_params)
+    app = FastAPI(title="RS-Server", version=api_version, lifespan=lifespan, **docs_params(router_prefix))
 
     # Configure OpenTelemetry
     init_opentelemetry.init_traces(app, settings.SERVICE_NAME)
@@ -239,12 +232,5 @@ def init_app(  # pylint: disable=too-many-locals, too-many-statements
             allow_credentials=True,
         )
 
-    @app.middleware("http")
-    async def modify_openapi_content_type(request: Request, call_next):
-        response = await call_next(request)
-        if request.url.path == app.openapi_url:
-            # Replace content-type header
-            response.headers["Content-Type"] = "application/vnd.oai.openapi+json;version=3.0"
-        return response
-
-    return app
+    # Finally, apply stac-fastapi openapi patch to comply with the STAC API spec
+    return update_openapi(app)

--- a/services/common/rs_server_common/settings.py
+++ b/services/common/rs_server_common/settings.py
@@ -15,6 +15,7 @@
 """Store diverse objects and values used throughout the application."""
 
 import os
+from os import environ as env
 
 from httpx import AsyncClient
 from starlette.requests import Request
@@ -52,6 +53,24 @@ STAC_BROWSER_URLS: list[str] = [url.strip() for url in os.environ.get("STAC_BROW
 def request_from_stacbrowser(request: Request) -> bool:
     """Return if the HTTP request comes from the STAC browser."""
     return bool((origin := request.headers.get("origin")) and (origin.rstrip("/") in STAC_BROWSER_URLS))
+
+
+def docs_params(prefix: str = "") -> dict[str, str]:
+    """
+    Return the docs parameters for the FastAPI application.
+
+    Args:
+        prefix (str, optional): Prefix to prepend to default values, when RSPY_DOCS_URL is not set. Defaults to "".
+
+    Returns:
+        dict[str, str]: dict with FastAPI docs_url and openapi_url keys.
+    """
+    # For cluster deployment: override the swagger /docs URL from an environment variable.
+    # Also set the openapi.json URL under the same path.
+    if "RSPY_DOCS_URL" in env:
+        docs_url = env["RSPY_DOCS_URL"].strip("/")
+        return {"docs_url": f"/{docs_url}", "openapi_url": f"/{docs_url}/openapi.json"}
+    return {"docs_url": prefix + "/api.html", "openapi_url": prefix + "/api"}  # Default values from stac-fastapi
 
 
 ###################

--- a/services/common/rs_server_common/utils/pytest/pytest_utils.py
+++ b/services/common/rs_server_common/utils/pytest/pytest_utils.py
@@ -102,7 +102,7 @@ async def mock_oauth2(  # pylint: disable=too-many-arguments
         client.follow_redirects = old_follow_redirects
 
     if assert_success:
-        assert response.is_success  # nosec
+        assert response.is_success, f"{endpoint} => {response}"  # nosec
 
     # After this, if successful, we should have a cookie with the authentication information.
     # Except for the logout endpoint which should have removed the cookie.

--- a/services/common/tests/test_settings.py
+++ b/services/common/tests/test_settings.py
@@ -1,0 +1,61 @@
+# Copyright 2025 CS Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for settings module."""
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from rs_server_common.settings import docs_params
+
+
+def test_docs_params_default(monkeypatch: MonkeyPatch):
+    """
+    Test that docs_params() returns the default values.
+
+    Args:
+        monkeypatch (MonkeyPatch): pytest's MonkeyPatch fixture used to temporarily remove the
+            "RSPY_DOCS_URL" environment variable for this test.
+    """
+    monkeypatch.delenv("RSPY_DOCS_URL", raising=False)
+    result = docs_params()
+    assert result == {"docs_url": "/api.html", "openapi_url": "/api"}
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        ("docs", {"docs_url": "/docs", "openapi_url": "/docs/openapi.json"}),
+        ("/docs/", {"docs_url": "/docs", "openapi_url": "/docs/openapi.json"}),
+        ("//my/path//", {"docs_url": "/my/path", "openapi_url": "/my/path/openapi.json"}),
+        ("", {"docs_url": "/", "openapi_url": "//openapi.json"}),
+    ],
+)
+def test_docs_params_with_env(monkeypatch: MonkeyPatch, env_value: str, expected: dict[str, str]):
+    """
+    Test that docs_params() uses the RSPY_DOCS_URL environment variable.
+
+    Args:
+        monkeypatch : MonkeyPatch
+            pytest's MonkeyPatch fixture used to temporarily set the
+            "RSPY_DOCS_URL" environment variable for each test case.
+        env_value : str
+            The value assigned to the "RSPY_DOCS_URL" environment variable.
+            May contain leading/trailing slashes or be empty.
+        expected : dict[str, str]
+            The expected dictionary output from docs_params() for the given
+            env_value.
+    """
+    monkeypatch.setenv("RSPY_DOCS_URL", env_value)
+    result = docs_params()
+    assert result == expected

--- a/services/frontend/resources/services.yml
+++ b/services/frontend/resources/services.yml
@@ -42,17 +42,17 @@ info:
     ---
 services:
   adgs:
-    openapi_url: http://localhost:8001/openapi.json
+    openapi_url: http://localhost:8001/auxip/api
     change_tags:
       "": ADGS stations
       Filter Extension: ADGS (Filter Extension)
   cadip:
-    openapi_url: http://localhost:8002/openapi.json
+    openapi_url: http://localhost:8002/cadip/api
     change_tags:
       "": CADIP stations
       Filter Extension: CADIP (Filter Extension)
   catalog:
-    openapi_url: http://localhost:8003/api
+    openapi_url: http://localhost:8003/catalog/api
     change_tags:
       "": Catalog
       Liveliness/Readiness: Catalog (Liveliness/Readiness)

--- a/services/staging/rs_server_staging/main.py
+++ b/services/staging/rs_server_staging/main.py
@@ -103,10 +103,10 @@ class JobsFormatError(Exception):
     """Exception raised when an error occurred during the init of a provider."""
 
 
-def must_be_authenticated(path: str) -> bool:
+def must_be_authenticated(path: str, prefix: str = "") -> bool:
     """Return true if a user must be authenticated to use this endpoint route path."""
 
-    no_auth = (path in ["/api", "/api.html", "/health", "/_mgmt/ping"]) or path.startswith("/auth/")
+    no_auth = (path in [prefix + "/api", prefix + "/api.html", "/health", "/_mgmt/ping"]) or path.startswith("/auth/")
     return not no_auth
 
 

--- a/tests/app.py
+++ b/tests/app.py
@@ -16,11 +16,12 @@
 
 import os
 
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, FastAPI, Request
 from rs_server_adgs.api.adgs_search import MockPgstacAdgs
 from rs_server_adgs.fastapi.adgs_routers import adgs_routers
 from rs_server_cadip.api.cadip_search import MockPgstacCadip
 from rs_server_cadip.fastapi.cadip_routers import cadip_routers
+from rs_server_common.authentication.oauth2 import SWAGGER_HOMEPAGE
 from rs_server_common.fastapi_app import init_app as init_app_with_args
 from rs_server_common.stac_api_common import MockPgstac
 from rs_server_common.utils.error_handlers import register_stac_exception_handlers
@@ -43,9 +44,21 @@ class MockPgstacTest(MockPgstac):
         raise RuntimeError(f"Invalid router_prefix or endpoint: {router_prefix!r} / {endpoint!r}")
 
 
+def swagger_router() -> APIRouter:
+    """Returns a router simulating the frontend swagger page to make oauth2 tests work"""
+    router = APIRouter(tags=["Swagger"])
+
+    @router.get(SWAGGER_HOMEPAGE)
+    async def get_docs():
+        """Endpoint must exist for oauth2 tests to work"""
+        return ""
+
+    return router
+
+
 def init_app(router_prefix: str = "") -> FastAPI:
     """Run all routers for the tests."""
-    routers = adgs_routers + cadip_routers
+    routers = adgs_routers + cadip_routers + [swagger_router()]
     app: FastAPI = init_app_with_args(
         api_version="test",
         routers=routers,

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -16,21 +16,24 @@
 
 import json
 import os
+from typing import cast
 
 import pytest
 import responses
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from pytest_httpx import HTTPXMock
 from rs_server_common.authentication import authentication, oauth2
 from rs_server_common.authentication.apikey import APIKEY_HEADER, ttl_cache
 from rs_server_common.authentication.authentication import authenticate
 from rs_server_common.authentication.keycloak_util import KCInfo
+from rs_server_common.settings import docs_params
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.pytest.pytest_utils import mock_oauth2
 from rs_server_common.utils.utils2 import AuthInfo
 from starlette import status
 from starlette.datastructures import State
+from starlette.routing import Route
 
 from tests.app import ROUTER_PREFIX_AUXIP, ROUTER_PREFIX_CADIP
 
@@ -188,7 +191,7 @@ async def test_oauth2_security(mocker, client):
     ids=["auxip", "cadip"],
 )
 async def test_endpoints_security(  # pylint: disable=too-many-arguments, too-many-locals
-    fastapi_app,
+    fastapi_app: FastAPI,
     client,
     mocker,
     monkeypatch,
@@ -254,14 +257,22 @@ async def test_endpoints_security(  # pylint: disable=too-many-arguments, too-ma
             status_code=status.HTTP_403_FORBIDDEN,
         )
 
+    openapi_urls = docs_params(fastapi_app.state.router_prefix).values()
+
     # If we test the oauth2 authentication, we login the user.
     # His authentication information is saved in the client session cookies.
     if test_oauth2:
         await mock_oauth2(mocker, client, "/auth/login", oauth2_user_id, oauth2_username, oauth2_roles)
 
     # For each adgs or cadip api endpoint
-    for route in fastapi_app.router.routes:
-        if not route.path.startswith(("/adgs/", "/auxip/", "/cadip/")):
+    for base_route in fastapi_app.router.routes:
+        route = cast(Route, base_route)
+        if (
+            route.path in openapi_urls
+            or not route.path.startswith(("/adgs/", "/auxip/", "/cadip/"))
+            or not route.methods
+        ):
+            logger.debug(f"Skipping {route.path}")
             continue
 
         # For each method (get, post, ...)


### PR DESCRIPTION
Change AUXIP and CADIP applications to be compliant to STAC specification regarding OpenAPI service-desc links.