### PR TITLE
Update to eodag 3.8.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1363,14 +1363,14 @@ poetry = ["poetry"]
 
 [[package]]
 name = "eodag"
-version = "3.7.0"
+version = "3.8.0"
 description = "Earth Observation Data Access Gateway"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "eodag-3.7.0-py3-none-any.whl", hash = "sha256:48d13a37479d209064fd286842b483ff5bd2629e31cc36e5b815e0b347d69a62"},
-    {file = "eodag-3.7.0.tar.gz", hash = "sha256:c253918b24744232cdac8bc4b97ff0d01fda2cf5e8645279bf8eb68b7ae8f19e"},
+    {file = "eodag-3.8.0-py3-none-any.whl", hash = "sha256:ec35db25495f06fe29cd479e872652c1a4c4e0cecd5625d45d2870a77a961b6a"},
+    {file = "eodag-3.8.0.tar.gz", hash = "sha256:c49f3b93b2495bf280b8192653c8a4b43c58d22c2b773480f9bda3a7e834b971"},
 ]
 
 [package.dependencies]
@@ -1397,7 +1397,6 @@ stream-zip = "*"
 tqdm = "*"
 typing_extensions = ">=4.8.0"
 urllib3 = "*"
-Whoosh = "*"
 
 [package.extras]
 all = ["eodag[all-providers,csw,server,tutorials]"]
@@ -5256,7 +5255,7 @@ authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
 cachetools = ">=5.5.2"
-eodag = "==v3.7.0"
+eodag = "==v3.8.0"
 fastapi = "^0.116.1"
 filelock = ">=3.16.1"
 geojson-pydantic = "2.0.0"
@@ -6393,19 +6392,6 @@ MarkupSafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
-
-[[package]]
-name = "whoosh"
-version = "2.7.4"
-description = "Fast, pure-Python full text indexing, search, and spell checking library."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "Whoosh-2.7.4-py2.py3-none-any.whl", hash = "sha256:aa39c3c3426e3fd107dcb4bde64ca1e276a65a889d9085a6e4b54ba82420a852"},
-    {file = "Whoosh-2.7.4.tar.gz", hash = "sha256:7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83"},
-    {file = "Whoosh-2.7.4.zip", hash = "sha256:e0857375f63e9041e03fedd5b7541f97cf78917ac1b6b06c1fcc9b45375dda69"},
-]
 
 [[package]]
 name = "wrapt"

--- a/services/adgs/poetry.lock
+++ b/services/adgs/poetry.lock
@@ -931,14 +931,14 @@ packaging = "*"
 
 [[package]]
 name = "eodag"
-version = "3.7.0"
+version = "3.8.0"
 description = "Earth Observation Data Access Gateway"
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
 files = [
-    {file = "eodag-3.7.0-py3-none-any.whl", hash = "sha256:48d13a37479d209064fd286842b483ff5bd2629e31cc36e5b815e0b347d69a62"},
-    {file = "eodag-3.7.0.tar.gz", hash = "sha256:c253918b24744232cdac8bc4b97ff0d01fda2cf5e8645279bf8eb68b7ae8f19e"},
+    {file = "eodag-3.8.0-py3-none-any.whl", hash = "sha256:ec35db25495f06fe29cd479e872652c1a4c4e0cecd5625d45d2870a77a961b6a"},
+    {file = "eodag-3.8.0.tar.gz", hash = "sha256:c49f3b93b2495bf280b8192653c8a4b43c58d22c2b773480f9bda3a7e834b971"},
 ]
 
 [package.dependencies]
@@ -965,7 +965,6 @@ stream-zip = "*"
 tqdm = "*"
 typing_extensions = ">=4.8.0"
 urllib3 = "*"
-Whoosh = "*"
 
 [package.extras]
 all = ["eodag[all-providers,csw,server,tutorials]"]
@@ -3158,7 +3157,7 @@ authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
 cachetools = ">=5.5.2"
-eodag = "==v3.7.0"
+eodag = "==v3.8.0"
 fastapi = "^0.116.1"
 filelock = ">=3.16.1"
 geojson-pydantic = "2.0.0"
@@ -3718,19 +3717,6 @@ python-versions = "*"
 groups = ["main", "dev"]
 files = [
     {file = "version_parser-1.0.1.tar.gz", hash = "sha256:7320b00cab8a04694206818c9129864dd0783cec0c0eff25b1c922e7d838dbc0"},
-]
-
-[[package]]
-name = "whoosh"
-version = "2.7.4"
-description = "Fast, pure-Python full text indexing, search, and spell checking library."
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "Whoosh-2.7.4-py2.py3-none-any.whl", hash = "sha256:aa39c3c3426e3fd107dcb4bde64ca1e276a65a889d9085a6e4b54ba82420a852"},
-    {file = "Whoosh-2.7.4.tar.gz", hash = "sha256:7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83"},
-    {file = "Whoosh-2.7.4.zip", hash = "sha256:e0857375f63e9041e03fedd5b7541f97cf78917ac1b6b06c1fcc9b45375dda69"},
 ]
 
 [[package]]

--- a/services/cadip/poetry.lock
+++ b/services/cadip/poetry.lock
@@ -931,14 +931,14 @@ packaging = "*"
 
 [[package]]
 name = "eodag"
-version = "3.7.0"
+version = "3.8.0"
 description = "Earth Observation Data Access Gateway"
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
 files = [
-    {file = "eodag-3.7.0-py3-none-any.whl", hash = "sha256:48d13a37479d209064fd286842b483ff5bd2629e31cc36e5b815e0b347d69a62"},
-    {file = "eodag-3.7.0.tar.gz", hash = "sha256:c253918b24744232cdac8bc4b97ff0d01fda2cf5e8645279bf8eb68b7ae8f19e"},
+    {file = "eodag-3.8.0-py3-none-any.whl", hash = "sha256:ec35db25495f06fe29cd479e872652c1a4c4e0cecd5625d45d2870a77a961b6a"},
+    {file = "eodag-3.8.0.tar.gz", hash = "sha256:c49f3b93b2495bf280b8192653c8a4b43c58d22c2b773480f9bda3a7e834b971"},
 ]
 
 [package.dependencies]
@@ -965,7 +965,6 @@ stream-zip = "*"
 tqdm = "*"
 typing_extensions = ">=4.8.0"
 urllib3 = "*"
-Whoosh = "*"
 
 [package.extras]
 all = ["eodag[all-providers,csw,server,tutorials]"]
@@ -3158,7 +3157,7 @@ authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
 cachetools = ">=5.5.2"
-eodag = "==v3.7.0"
+eodag = "==v3.8.0"
 fastapi = "^0.116.1"
 filelock = ">=3.16.1"
 geojson-pydantic = "2.0.0"
@@ -3718,19 +3717,6 @@ python-versions = "*"
 groups = ["main", "dev"]
 files = [
     {file = "version_parser-1.0.1.tar.gz", hash = "sha256:7320b00cab8a04694206818c9129864dd0783cec0c0eff25b1c922e7d838dbc0"},
-]
-
-[[package]]
-name = "whoosh"
-version = "2.7.4"
-description = "Fast, pure-Python full text indexing, search, and spell checking library."
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "Whoosh-2.7.4-py2.py3-none-any.whl", hash = "sha256:aa39c3c3426e3fd107dcb4bde64ca1e276a65a889d9085a6e4b54ba82420a852"},
-    {file = "Whoosh-2.7.4.tar.gz", hash = "sha256:7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83"},
-    {file = "Whoosh-2.7.4.zip", hash = "sha256:e0857375f63e9041e03fedd5b7541f97cf78917ac1b6b06c1fcc9b45375dda69"},
 ]
 
 [[package]]

--- a/services/catalog/poetry.lock
+++ b/services/catalog/poetry.lock
@@ -943,14 +943,14 @@ packaging = "*"
 
 [[package]]
 name = "eodag"
-version = "3.7.0"
+version = "3.8.0"
 description = "Earth Observation Data Access Gateway"
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
 files = [
-    {file = "eodag-3.7.0-py3-none-any.whl", hash = "sha256:48d13a37479d209064fd286842b483ff5bd2629e31cc36e5b815e0b347d69a62"},
-    {file = "eodag-3.7.0.tar.gz", hash = "sha256:c253918b24744232cdac8bc4b97ff0d01fda2cf5e8645279bf8eb68b7ae8f19e"},
+    {file = "eodag-3.8.0-py3-none-any.whl", hash = "sha256:ec35db25495f06fe29cd479e872652c1a4c4e0cecd5625d45d2870a77a961b6a"},
+    {file = "eodag-3.8.0.tar.gz", hash = "sha256:c49f3b93b2495bf280b8192653c8a4b43c58d22c2b773480f9bda3a7e834b971"},
 ]
 
 [package.dependencies]
@@ -977,7 +977,6 @@ stream-zip = "*"
 tqdm = "*"
 typing_extensions = ">=4.8.0"
 urllib3 = "*"
-Whoosh = "*"
 
 [package.extras]
 all = ["eodag[all-providers,csw,server,tutorials]"]
@@ -3458,7 +3457,7 @@ authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
 cachetools = ">=5.5.2"
-eodag = "==v3.7.0"
+eodag = "==v3.8.0"
 fastapi = "^0.116.1"
 filelock = ">=3.16.1"
 geojson-pydantic = "2.0.0"
@@ -4066,19 +4065,6 @@ MarkupSafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
-
-[[package]]
-name = "whoosh"
-version = "2.7.4"
-description = "Fast, pure-Python full text indexing, search, and spell checking library."
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "Whoosh-2.7.4-py2.py3-none-any.whl", hash = "sha256:aa39c3c3426e3fd107dcb4bde64ca1e276a65a889d9085a6e4b54ba82420a852"},
-    {file = "Whoosh-2.7.4.tar.gz", hash = "sha256:7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83"},
-    {file = "Whoosh-2.7.4.zip", hash = "sha256:e0857375f63e9041e03fedd5b7541f97cf78917ac1b6b06c1fcc9b45375dda69"},
-]
 
 [[package]]
 name = "wrapt"

--- a/services/common/poetry.lock
+++ b/services/common/poetry.lock
@@ -898,14 +898,14 @@ packaging = "*"
 
 [[package]]
 name = "eodag"
-version = "3.7.0"
+version = "3.8.0"
 description = "Earth Observation Data Access Gateway"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "eodag-3.7.0-py3-none-any.whl", hash = "sha256:48d13a37479d209064fd286842b483ff5bd2629e31cc36e5b815e0b347d69a62"},
-    {file = "eodag-3.7.0.tar.gz", hash = "sha256:c253918b24744232cdac8bc4b97ff0d01fda2cf5e8645279bf8eb68b7ae8f19e"},
+    {file = "eodag-3.8.0-py3-none-any.whl", hash = "sha256:ec35db25495f06fe29cd479e872652c1a4c4e0cecd5625d45d2870a77a961b6a"},
+    {file = "eodag-3.8.0.tar.gz", hash = "sha256:c49f3b93b2495bf280b8192653c8a4b43c58d22c2b773480f9bda3a7e834b971"},
 ]
 
 [package.dependencies]
@@ -932,7 +932,6 @@ stream-zip = "*"
 tqdm = "*"
 typing_extensions = ">=4.8.0"
 urllib3 = "*"
-Whoosh = "*"
 
 [package.extras]
 all = ["eodag[all-providers,csw,server,tutorials]"]
@@ -3752,19 +3751,6 @@ MarkupSafe = ">=2.1.1"
 watchdog = ["watchdog (>=2.3)"]
 
 [[package]]
-name = "whoosh"
-version = "2.7.4"
-description = "Fast, pure-Python full text indexing, search, and spell checking library."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "Whoosh-2.7.4-py2.py3-none-any.whl", hash = "sha256:aa39c3c3426e3fd107dcb4bde64ca1e276a65a889d9085a6e4b54ba82420a852"},
-    {file = "Whoosh-2.7.4.tar.gz", hash = "sha256:7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83"},
-    {file = "Whoosh-2.7.4.zip", hash = "sha256:e0857375f63e9041e03fedd5b7541f97cf78917ac1b6b06c1fcc9b45375dda69"},
-]
-
-[[package]]
 name = "wrapt"
 version = "1.17.3"
 description = "Module for decorators, wrappers and monkey patching."
@@ -3890,4 +3876,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "8e56b6563f21c6f5d3b53ec4670ae89f6b5139cc0f2e7534135d7c57a5601bc0"
+content-hash = "33f569d3fcf6a6f02bf3f078b71b32cef19de706d45c15c81ecf25af12e3b174"

--- a/services/common/pyproject.toml
+++ b/services/common/pyproject.toml
@@ -56,7 +56,7 @@ starlette = ">=0.47.2,<0.48"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
 sqlalchemy = "^2.0.43"
-eodag = "==v3.7.0"
+eodag = "==v3.8.0"
 # NOTE: to use a forked eodag version we would use:
 # eodag = { git = "https://github.com/jgaucher-cs/eodag", branch = "my-branch-name" }
 pydantic = ">=2.9.2,<2.12.0" # see https://github.com/pyupio/safety/issues/673

--- a/services/staging/poetry.lock
+++ b/services/staging/poetry.lock
@@ -1248,14 +1248,14 @@ zict = ">=3.0.0"
 
 [[package]]
 name = "eodag"
-version = "3.7.0"
+version = "3.8.0"
 description = "Earth Observation Data Access Gateway"
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
 files = [
-    {file = "eodag-3.7.0-py3-none-any.whl", hash = "sha256:48d13a37479d209064fd286842b483ff5bd2629e31cc36e5b815e0b347d69a62"},
-    {file = "eodag-3.7.0.tar.gz", hash = "sha256:c253918b24744232cdac8bc4b97ff0d01fda2cf5e8645279bf8eb68b7ae8f19e"},
+    {file = "eodag-3.8.0-py3-none-any.whl", hash = "sha256:ec35db25495f06fe29cd479e872652c1a4c4e0cecd5625d45d2870a77a961b6a"},
+    {file = "eodag-3.8.0.tar.gz", hash = "sha256:c49f3b93b2495bf280b8192653c8a4b43c58d22c2b773480f9bda3a7e834b971"},
 ]
 
 [package.dependencies]
@@ -1282,7 +1282,6 @@ stream-zip = "*"
 tqdm = "*"
 typing_extensions = ">=4.8.0"
 urllib3 = "*"
-Whoosh = "*"
 
 [package.extras]
 all = ["eodag[all-providers,csw,server,tutorials]"]
@@ -4687,7 +4686,7 @@ authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
 cachetools = ">=5.5.2"
-eodag = "==v3.7.0"
+eodag = "==v3.8.0"
 fastapi = "^0.116.1"
 filelock = ">=3.16.1"
 geojson-pydantic = "2.0.0"
@@ -5369,19 +5368,6 @@ MarkupSafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
-
-[[package]]
-name = "whoosh"
-version = "2.7.4"
-description = "Fast, pure-Python full text indexing, search, and spell checking library."
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "Whoosh-2.7.4-py2.py3-none-any.whl", hash = "sha256:aa39c3c3426e3fd107dcb4bde64ca1e276a65a889d9085a6e4b54ba82420a852"},
-    {file = "Whoosh-2.7.4.tar.gz", hash = "sha256:7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83"},
-    {file = "Whoosh-2.7.4.zip", hash = "sha256:e0857375f63e9041e03fedd5b7541f97cf78917ac1b6b06c1fcc9b45375dda69"},
-]
 
 [[package]]
 name = "wrapt"


### PR DESCRIPTION
Update to:
- https://github.com/CS-SI/eodag/releases/tag/v3.8.0

Refactoring and Performance Improvements:
- whoosh removal by @sbrunato in https://github.com/CS-SI/eodag/pull/1741
    **3.35x faster** on initialization + external product types fetch