### PR TITLE
Add missing env variable to allow staging PRIP products

### DIFF
--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -144,6 +144,7 @@ class Staging(
         self.server_url = [
             os.getenv("RSPY_HOST_CADIP", "http://127.0.0.1:8002"),
             os.getenv("RSPY_HOST_ADGS", "http://127.0.0.1:8001"),
+            os.getenv("RSPY_HOST_PRIP", "http://127.0.0.1:8005"),
         ]
 
         self.catalog_url: str = os.environ.get(


### PR DESCRIPTION
Fixes to allow to stage PRIP products:

- https://github.com/RS-PYTHON/rs-server/pull/1531
- https://github.com/RS-PYTHON/rs-client-libraries/pull/134
- https://github.com/RS-PYTHON/rs-demo/pull/200
- https://github.com/RS-PYTHON/rs-helm/pull/168