### PR TITLE
RSPY-850 - Remove space characters when requesting several OData values

### DIFF
--- a/services/cadip/rs_server_cadip/api/cadip_search.py
+++ b/services/cadip/rs_server_cadip/api/cadip_search.py
@@ -145,8 +145,8 @@ class MockPgstacCadip(MockPgstac):
             session_features (list[Item]): sessions as Item objects
         """
 
-        # Join session ids with ', '
-        features_ids = ", ".join(feature.id for feature in session_features)
+        # Join session ids with ','
+        features_ids = ",".join(feature.id for feature in session_features)
         logger.debug(f"Searching for CADIP files at station {station} for session ids: {features_ids}")
 
         assets: list[dict] = []

--- a/services/cadip/rs_server_cadip/cadip_utils.py
+++ b/services/cadip/rs_server_cadip/cadip_utils.py
@@ -188,7 +188,7 @@ def cadip_map_mission(platform: str, constellation: str) -> str | None:
             config = next(sat[platform] for sat in data["satellites"] if platform in sat)
             satellite = config.get("code", None)
         if constellation:
-            satellites = ", ".join(
+            satellites = ",".join(
                 [
                     satellite_info["code"]
                     for satellite in data["satellites"]

--- a/services/common/rs_server_common/data_retrieval/eodag_provider.py
+++ b/services/common/rs_server_common/data_retrieval/eodag_provider.py
@@ -156,7 +156,7 @@ class EodagProvider(Provider):
     def _handle_multiple_values(self, mapped_search_args: dict, values: list | str, singular_key: str, plural_key: str):
         value = values[0] if isinstance(values, list) and len(values) == 1 else values
         key = plural_key if isinstance(value, list) else singular_key
-        mapped_search_args[key] = ", ".join(f"'{p}'" for p in value) if isinstance(value, list) else f"'{value}'"
+        mapped_search_args[key] = ",".join(f"'{p}'" for p in value) if isinstance(value, list) else f"'{value}'"
 
     def _specific_search(self, **kwargs) -> SearchResult | list:  # pylint: disable=too-many-branches,too-many-locals
         """
@@ -196,10 +196,10 @@ class EodagProvider(Provider):
             if platform := kwargs.pop("Satellite", None):
                 self._handle_multiple_values(mapped_search_args, platform, "platform", "platforms")
 
-        for auxip_key in ("attr_ptype", "platformSerialIdentifier", "platformShortName"):
-            # Handle AUXIP parameters that can have one or several values
-            if values := kwargs.pop(auxip_key, None):
-                self._handle_multiple_values(mapped_search_args, values, auxip_key, auxip_key + "s")
+        for multivalued_key in ("attr_ptype", "platformSerialIdentifier", "platformShortName"):
+            # Handle AUXIP/PRIP parameters that can have one or several values
+            if values := kwargs.pop(multivalued_key, None):
+                self._handle_multiple_values(mapped_search_args, values, multivalued_key, multivalued_key + "s")
 
         if date_time := kwargs.pop("PublicationDate", False):
             # Since now both for files and sessions, time interval is optional, map it if provided.

--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -959,7 +959,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                 iterable = value if isinstance(value, list) else value.split(",")
                 s = {v.strip() for v in iterable}
                 intersection = intersection.intersection(s) if i else s  # type: ignore
-            intersection = ", ".join(intersection) if intersection else None
+            intersection = ",".join(intersection) if intersection else None
             logger.debug(f"comma-separated list conflict resolution result: {intersection}")
 
         return intersection, not intersection

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -416,7 +416,7 @@ class Staging(
         filter_object = {
             "collections": catalog_collection,
             "filter-lang": "cql2-text",
-            "filter": f"id IN ({', '.join(ids)})",
+            "filter": f"id IN ({','.join(ids)})",
             "limit": str(len(ids)),
         }
 

--- a/services/staging/tests/test_processors/test_staging_catalog.py
+++ b/services/staging/tests/test_processors/test_staging_catalog.py
@@ -68,7 +68,7 @@ class TestStagingCatalog:
         expected_filter_object = {
             "collections": "test_collection",
             "filter-lang": "cql2-text",
-            "filter": "id IN ('1', '2')",
+            "filter": "id IN ('1','2')",
             "limit": "2",
         }
         # Assert that requests.get was called with the correct parameters

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -110,8 +110,8 @@ class TestConstellationMapping:
             ("sentinel-2b", "sentinel-2", "S2B"),
             ("sentinel-1a", "sentinel-1", "S1A"),
             ("sentinel-5p", "sentinel-5P", "S5P"),
-            (None, "sentinel-1", "S1A, S1B, S1C, S1D"),
-            (None, "sentinel-2", "S2A, S2B, S2C"),
+            (None, "sentinel-1", "S1A,S1B,S1C,S1D"),
+            (None, "sentinel-2", "S2A,S2B,S2C"),
             (None, "sentinel-5P", "S5P"),
         ],
     )
@@ -1620,9 +1620,9 @@ class TestFeatureCollectionOdataStacMapping:
         """Used to test if application correctly builds next/previous token."""
         base_cadip_uri = (
             "http://127.0.0.1:5000/Sessions?$filter=SessionId in ("
-            "'S1A_20200105072204051312', 'S1A_20200105072204051313', 'S1A_20200105072204051314', "
-            "'S1A_20200105072204051315', 'S1A_20200105072204051316', 'S1A_20200105072204051317', "
-            "'S1A_20200105072204051318', 'S1A_20200105072204051319', 'S1A_20200105072204051310', "
+            "'S1A_20200105072204051312','S1A_20200105072204051313','S1A_20200105072204051314',"
+            "'S1A_20200105072204051315','S1A_20200105072204051316','S1A_20200105072204051317',"
+            "'S1A_20200105072204051318','S1A_20200105072204051319','S1A_20200105072204051310',"
             "'S1A_20200105072204051311')&$orderby=PublicationDate desc&"
             f"$top=10&$skip={(int(page) - 1) * 10}"
         )
@@ -1868,15 +1868,15 @@ def test_search_parameters(
             "platformShortName": "sentinel-1",
         }
         query3 = {
-            "productType": "AUX_OBMEMC, type2",
-            "platformShortName": "sentinel-1, sentinel-2",
+            "productType": "AUX_OBMEMC,type2",
+            "platformShortName": "sentinel-1,sentinel-2",
         }
     elif cadip:
         query2 = {
             "Satellite": "S1A",
         }
         query3 = {
-            "Satellite": "S1A, S2A",
+            "Satellite": "S1A,S2A",
         }
     else:
         raise NotImplementedError
@@ -1914,7 +1914,7 @@ def test_search_parameters(
     # User given parameters
 
     # Static values
-    user_ids = "id1, id2"
+    user_ids = "id1,id2"
     user_datetime = "2020-01-01T00:00:00.000Z/2023-01-01T00:00:00.000Z"
     user_limit = 15  # User-defined 'limit' value has higher priority over the collection hardcoded 'top' value
     user_params = {
@@ -2047,7 +2047,7 @@ def test_search_parameters(
                 )
             elif cadip:
                 # Add quote to the user_id
-                user_ids_with_quote = ", ".join([f"'{user_id}'" for user_id in user_ids.split(", ")])
+                user_ids_with_quote = ",".join([f"'{user_id}'" for user_id in user_ids.split(",")])
                 odata_no_query = (
                     "http://127.0.0.1:5000/Sessions?$filter="
                     f"SessionId in ({user_ids_with_quote}) "
@@ -2129,7 +2129,7 @@ def test_search_parameters(
                         if value is None:
                             return None
                         if "," in value:
-                            values = ", ".join([f"'{val}'" for val in value.split(", ")])
+                            values = ",".join([f"'{val}'" for val in value.split(",")])
                             return f"({values})"
                         return f"'{value}'"
 


### PR DESCRIPTION
PRIP S3A does not accept requests containing the "in" operator with space characters.

This PR removes these characters to always make OData requests without space character.

Pull requests:
- https://github.com/RS-PYTHON/rs-server/pull/1557
- https://github.com/RS-PYTHON/rs-testmeans/pull/62