### PR TITLE
RSPY-866: Change CQL2 filtering lte/gte operators for CADIP

### DIFF
--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -481,7 +481,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                 ring = ring + [ring[0]]
             return "POLYGON((" + ", ".join(f"{x} {y}" for x, y in ring) + "))"
 
-        def read_cql(filt: dict):
+        def read_cql(filt: dict, is_cadip: bool = False):
             """Use a recursive function to read all CQL filter levels"""
             if not filt:
                 return
@@ -517,7 +517,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
 
             # Read temporal operators
             if op in temporal_operations:
-                temporal_query: str = temporal_op_query(op, args, self.temporal_mapping)
+                temporal_query: str = temporal_op_query(op, args, self.temporal_mapping, is_cadip=is_cadip)
                 logger.debug(f"Temporal operator {op} with args {args} -> {temporal_query}")
                 stac_params[op] = temporal_query
                 return
@@ -529,7 +529,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
                     f"Invalid CQL2 filter, only '=', 'and' and temporal operators are allowed, got '{op}': {format_dict(filt)}",  # noqa: E501 # pylint: disable=line-too-long
                 )
             for sub_filter in args:
-                read_cql(sub_filter)
+                read_cql(sub_filter, is_cadip=is_cadip)
 
         def read_query(query_arg: str | None):
             """Used to read query parameter cql2-text filter."""
@@ -574,7 +574,7 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
             params["filter"] = process_filter_extensions(params["filter"])
 
         # Read filter
-        read_cql(params.pop("filter", {}))
+        read_cql(params.pop("filter", {}), is_cadip=self.cadip)
         read_query(self.request.query_params.get("filter"))
 
         # Read the query

--- a/services/common/rs_server_common/stac_cql2.py
+++ b/services/common/rs_server_common/stac_cql2.py
@@ -104,7 +104,7 @@ def parse_interval(interval: str) -> timedelta:
     raise ValueError(f"Invalid interval format: {interval}")
 
 
-def temporal_op_query(op: str, args: list[dict], temporal_mapping: dict[str, str]) -> str:
+def temporal_op_query(op: str, args: list[dict], temporal_mapping: dict[str, str], is_cadip: bool = False) -> str:
     """temporal operation query"""
     if op.lower() not in temporal_operations:
         raise ValueError(f"Invalid temporal operator: {op}")
@@ -119,10 +119,13 @@ def temporal_op_query(op: str, args: list[dict], temporal_mapping: dict[str, str
         .replace("lh", temporal_mapping[props[1 if len(props) > 1 else 0]["property"]])
         .replace("rl", strftime_millis(rrange[0]))
         .replace("rh", strftime_millis(rrange[1]))
-        .replace("<=", "lte")
-        .replace(">=", "gte")
+        # Note: lte and gte are currently not supported in Cadip stations, so we use lt and gt instead
+        # Whenever this gets fixed, remove the two ifs below and the "is_cadip" input
+        .replace("<=", "lte" if not is_cadip else "lt")
+        .replace(">=", "gte" if not is_cadip else "gt")
         .replace("=", "eq")
         .replace("<", "lt")
         .replace(">", "gt")
     )
+
     return f"({outq})"


### PR DESCRIPTION
Added a fix to replace lte and gte operators with lt and gt in case the filter is for a Cadip station.