### PR TITLE
RSPY-930 Fix STAC errors seen thanks to stac-browser 4.0.0

### DIFF
--- a/services/catalog/rs_server_catalog/data_management/stac_manager.py
+++ b/services/catalog/rs_server_catalog/data_management/stac_manager.py
@@ -97,7 +97,8 @@ class StacManager:
         for asset in list(content.get("assets", {}).values()):
             asset["auth:refs"] = ["s3"]
             if ALTERNATE_STRING in asset:
-                asset[ALTERNATE_STRING].update({"auth:refs": ["apikey", "openid", "oauth2"]})
+                for alt_asset in asset[ALTERNATE_STRING].values():
+                    alt_asset["auth:refs"] = ["apikey", "openid", "oauth2"]
         # Add the extension to the response root and to nested collections, items, ...
         # Do recursive calls to all nested fields, if defined
         for nested_field in ["collections", "features"]:

--- a/services/catalog/rs_server_catalog/utils.py
+++ b/services/catalog/rs_server_catalog/utils.py
@@ -32,7 +32,7 @@ DEFAULT_GEOM = {
     "type": "Polygon",
     "coordinates": [[[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]]],
 }
-DEFAULT_BBOX = (-180.0, -90.0, 180.0, 90.0)
+DEFAULT_BBOX = [-180.0, -90.0, 180.0, 90.0]
 
 # Regular expression pattern to match 's3://path/to/file'
 S3_KEY_PATTERN = r"^s3:\/\/[a-zA-Z0-9\-_.]+\/[a-zA-Z0-9\-_.\/]+$"

--- a/services/catalog/tests/test_endpoints/test_catalog_publish_feature_without_bucket_transfer_endpoint.py
+++ b/services/catalog/tests/test_endpoints/test_catalog_publish_feature_without_bucket_transfer_endpoint.py
@@ -94,7 +94,7 @@ class TestCatalogPublishFeatureWithoutBucketTransferEndpoint:
         assert feature_post_response.status_code == fastapi.status.HTTP_201_CREATED
         # Update the feature and PUT it into catalogDB
         updated_feature_sent = copy.deepcopy(a_correct_feature)
-        updated_feature_sent["bbox"] = [-180.0, -90.0, 180.0, 90.0]
+        updated_feature_sent["bbox"] = [1.43, 43.5, 1.45, 43.7]
         del updated_feature_sent["collection"]
 
         feature_put_response = client.put(


### PR DESCRIPTION
The addition of default bbox when geometry is null causes this STAC validation error:

```
$ stac-validator --verbose S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950.geojson 
```

```json
[
    {
        "version": "1.1.0",
        "path": "S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950.geojson",
        "schema": [
            "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/item.json"
        ],
        "valid_stac": false,
        "error_type": "JSONSchemaValidationError",
        "error_message": "{'id': 'S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950', 'bbox': [-180.0, -90.0, 180.0, 90.0], 'type': 'Feature', 'links': [{'rel': 'collection', 'type': 'application/json', 'href': 'https://rspy.ops.rs-python.eu/catalog/collections/suberti:timeline', 'auth:refs': ['apikey', 'openid', 'oauth2']}, {'rel': 'parent', 'type': 'application/json', 'href': 'https://rspy.ops.rs-python.eu/catalog/collections/suberti:timeline', 'auth:refs': ['apikey', 'openid', 'oauth2']}, {'rel': 'root', 'type': 'application/json', 'href': 'https://rspy.ops.rs-python.eu/catalog/', 'auth:refs': ['apikey', 'openid', 'oauth2']}, {'rel': 'self', 'type': 'application/geo+json', 'href': 'https://rspy.ops.rs-python.eu/catalog/collections/suberti:timeline/items/S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950', 'auth:refs': ['apikey', 'openid', 'oauth2']}], 'assets': {'S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950.tgz': {'href': 's3://prip-rs-playground/suberti/timeline/S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950/S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950.tgz', 'type': 'application/octet-stream', 'alternate': {'https': {'href': 'https://rspy.ops.rs-python.eu/catalog/collections/suberti:timeline/items/S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950/download/S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950.tgz'}, 'auth:refs': ['apikey', 'openid', 'oauth2']}, 'file:size': 914653, 'file:checksum': 'e430df60bda53bd17a161cfec248ae22', 'file:local_path': 'S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950/S1C_OPER_MPL_TIMELINE_20260114T173840_20260126T193950.tgz', 'eviction_datetime': '2036-01-12T12:14:31.946000Z', 'auth:refs': ['s3']}}, 'geometry': None, 'collection': 'timeline', 'properties': {'owner': 'suberti', 'created': '2026-01-14T12:14:31.946000Z', 'expires': '2026-02-13T15:08:17.015539Z', 'updated': '2026-01-14T15:08:17.003397Z', 'auxip:id': '94bd12a2-f142-11f0-9e6f-0050561a7772', 'datetime': '2026-01-14T17:38:00Z', 'platform': 'sentinel-1c', 'published': '2026-01-14T15:08:17.003384Z', 'end_datetime': '2026-01-26T19:39:00Z', 'product:type': 'MPL_TIMELINE', 'constellation': 'sentinel-1', 'start_datetime': '2026-01-14T17:38:00Z', 'auth:schemes': {'apikey': {'type': 'apiKey', 'description': 'API key generated using https://apikeymanager.ops.rs-python.eu/docs#/Manage%20API%20keys/get_new_api_key_auth_api_key_new_get', 'name': 'x-api-key', 'in': 'header'}, 'openid': {'type': 'openIdConnect', 'description': 'OpenID Connect', 'openIdConnectUrl': 'https://iam.ops.rs-python.eu/realms/rspy/.well-known/openid-configuration'}, 'oauth2': {'type': 'oauth2', 'description': 'OAuth2+PKCE Authorization Code Flow', 'flows': {'authorizationCode': {'authorizationUrl': 'https://iam.ops.rs-python.eu/realms/rspy/protocol/openid-connect/auth', 'tokenUrl': 'https://iam.ops.rs-python.eu/realms/rspy/protocol/openid-connect/token', 'scopes': {}}}}, 's3': {'type': 's3', 'description': 'S3'}}}, 'stac_version': '1.1.0', 'stac_extensions': ['https://home.rs-python.eu/auxip-stac-extension/v1.1.0/schema.json', 'https://stac-extensions.github.io/file/v2.1.0/schema.json', 'https://stac-extensions.github.io/timestamps/v1.1.0/schema.json', 'https://home.rs-python.eu/ownership-stac-extension/v1.1.0/schema.json', 'https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json', 'https://stac-extensions.github.io/authentication/v1.1.0/schema.json']} is not valid under any of the given schemas",
        "failed_schema": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/item.json",
        "error_verbose": {
            "validator": "oneOf",
            "validator_value": "[{'type': 'object', 'required': ['geometry', 'bbox'], 'properties': {'geometry': {'$ref': 'https://geojson.org/schema/Geometry.json'}, 'bbox': {'type': 'array', 'oneOf': [{'minItems': 4, 'maxItems': 4}, {'minItems': 6, 'maxItems': 6}], 'items': {'type': 'number'}}}}, {'type': 'object', 'required': ['geometry'], 'properties': {'geometry': {'type': 'null'}, 'bbox': {'not': {}}}}]",
            "schema": [
                {
                    "type": "object",
                    "required": [
                        "geometry",
                        "bbox"
                    ],
                    "properties": {
                        "geometry": {
                            "$ref": "https://geojson.org/schema/Geometry.json"
                        },
                        "bbox": {
                            "type": "array",
                            "oneOf": [
                                {
                                    "minItems": 4,
                                    "maxItems": 4
                                },
                                {
                                    "minItems": 6,
                                    "maxItems": 6
                                }
                            ],
                            "items": {
                                "type": "number"
                            }
                        }
                    }
                },
                {
                    "type": "object",
                    "required": [
                        "geometry"
                    ],
                    "properties": {
                        "geometry": {
                            "type": "null"
                        },
                        "bbox": {
                            "not": {}
                        }
                    }
                }
            ],
            "path_in_document": [],
            "path_in_schema": [
                "allOf",
                0,
                "allOf",
                1,
                "oneOf"
            ]
        },
        "recommendation": "If the error is unclear, please check the schema documentation at: https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/item.json"
    }
]
```

There is another problem.

https://github.com/stac-extensions/authentication states that auth:refs property must be added for assets and links.

But in the rs-server-catalog it is also added under the "alternate" object, which is wrong:
```python
        for asset in list(content.get("assets", {}).values()):
            asset["auth:refs"] = ["s3"]
            if ALTERNATE_STRING in asset:
                asset[ALTERNATE_STRING].update({"auth:refs": ["apikey", "openid", "oauth2"]})
```

it gives the following:
```json
      "alternate": {
        "https": {
          "href": "https://rspy.ops.rs-python.eu/catalog/collections/suberti:timeline/items/S1C_OPER_MPL_TIMELINE_20260116T172331_20260128T192326/download/S1C_OPER_MPL_TIMELINE_20260116T172331_20260128T192326.tgz"
        },
        "auth:refs": [
          "apikey",
          "openid",
          "oauth2"
        ]
      },
```

but the correct json should be:
```json
      "alternate": {
        "https": {
          "href": "https://rspy.ops.rs-python.eu/catalog/collections/suberti:timeline/items/S1C_OPER_MPL_TIMELINE_20260116T172331_20260128T192326/download/S1C_OPER_MPL_TIMELINE_20260116T172331_20260128T192326.tgz"
          "auth:refs": [
            "apikey",
            "openid",
            "oauth2"
          ]
        },
      },
```

And such items are not displayed anymore in stac-browser 4.0.0:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8af20e6d-ba01-4abe-9899-883c40c3bd36" />
