### PR TITLE
fix-staging-lock-in-swagger-ui

### DIFF
--- a/services/frontend/resources/build_aggregated_openapi.sh
+++ b/services/frontend/resources/build_aggregated_openapi.sh
@@ -151,8 +151,7 @@ if [[ " $@ " == *" --run-services "* ]]; then
     # Use postgres database
     run_local_service "../adgs" "rs_server_adgs.fastapi.adgs_app:app" 8001 "health"
     run_local_service "../cadip" "rs_server_cadip.fastapi.cadip_app:app" 8002 "health"
-    RSPY_LOCAL_MODE=1 \
-        run_local_service "../staging" "rs_server_staging.main:app" 8004 "_mgmt/ping"
+    run_local_service "../staging" "rs_server_staging.main:app" 8004 "_mgmt/ping"
     run_local_service "../prip" "rs_server_prip.fastapi.prip_app:app" 8005 "health"
     run_local_service "../edrs" "rs_server_edrs.fastapi.edrs_app:app" 8006 "health"
     run_local_service "../osam" "rs_server_osam.main:app" 7001 "_mgmt/ping"

--- a/services/staging/rs_server_staging/main.py
+++ b/services/staging/rs_server_staging/main.py
@@ -96,21 +96,31 @@ class JobsFormatError(Exception):
 def must_be_authenticated(path: str, prefix: str = "") -> bool:
     """Return true if a user must be authenticated to use this endpoint route path."""
 
-    no_auth = (path in [prefix + "/api", prefix + "/api.html", "/health", "/_mgmt/ping"]) or path.startswith("/auth/")
+    # Keep OpenAPI/Swagger endpoints publicly accessible so tooling (e.g. aggregated swagger generator)
+    # can fetch the schema without having to handle auth/redirect flows.
+    no_auth = (
+        path
+        in [
+            prefix + "/api",
+            prefix + "/api.html",
+            prefix + "/openapi.json",
+            "/openapi.json",
+            "/health",
+            "/_mgmt/ping",
+        ]
+        or path.startswith("/auth/")
+    )
     return not no_auth
 
 
-if common_settings.CLUSTER_MODE:
+async def just_for_the_lock_icon(
+    apikey_value: Annotated[str, Security(APIKEY_AUTH_HEADER)] = "",  # pylint: disable=unused-argument
+):
+    """Dummy function to add a lock icon in Swagger to enter an API key.
 
-    async def just_for_the_lock_icon(
-        apikey_value: Annotated[str, Security(APIKEY_AUTH_HEADER)] = "",  # pylint: disable=unused-argument
-    ):
-        """Dummy function to add a lock icon in Swagger to enter an API key."""
-
-else:
-
-    async def just_for_the_lock_icon():  # type: ignore # different signature than above
-        """In local mode it does nothing."""
+    Note: authentication is enforced by `AuthenticationMiddleware` (in cluster mode only),
+    this dependency exists only so the aggregated OpenAPI/Swagger shows secured endpoints.
+    """
 
 
 async def validate_request_dependency(request: Request):

--- a/services/staging/rs_server_staging/main.py
+++ b/services/staging/rs_server_staging/main.py
@@ -98,18 +98,14 @@ def must_be_authenticated(path: str, prefix: str = "") -> bool:
 
     # Keep OpenAPI/Swagger endpoints publicly accessible so tooling (e.g. aggregated swagger generator)
     # can fetch the schema without having to handle auth/redirect flows.
-    no_auth = (
-        path
-        in [
-            prefix + "/api",
-            prefix + "/api.html",
-            prefix + "/openapi.json",
-            "/openapi.json",
-            "/health",
-            "/_mgmt/ping",
-        ]
-        or path.startswith("/auth/")
-    )
+    no_auth = path in [
+        prefix + "/api",
+        prefix + "/api.html",
+        prefix + "/openapi.json",
+        "/openapi.json",
+        "/health",
+        "/_mgmt/ping",
+    ] or path.startswith("/auth/")
     return not no_auth
 
 


### PR DESCRIPTION
small fix related to https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-894 : the lock is not visible in the Swagger UI because openapi.json is not well regenerated. Fix:

- **`services/frontend/resources/build_aggregated_openapi.sh` (remove `RSPY_LOCAL_MODE=1` for staging):** The aggregated OpenAPI generator starts the services locally to fetch their schemas. For staging it was forcing `RSPY_LOCAL_MODE=1`, which makes `CLUSTER_MODE=False` and produces an OpenAPI spec without the API-key security/lock indicators. Removing that override makes staging start like the others (`RSPY_LOCAL_MODE=0`), so the generated staging OpenAPI matches cluster behavior.

- **`services/staging/rs_server_staging/main.py` (`no_auth` whitelist adds `/openapi.json`):** In cluster mode, the auth middleware can block/redirect requests without credentials. The generator must be able to fetch staging’s schema (`GET /openapi.json`) without handling auth flows, so `/openapi.json` (and `prefix + "/openapi.json"`) is whitelisted as public. This change is only to allow schema retrieval; it does not open the business endpoints.

- **`services/staging/rs_server_staging/main.py` (`just_for_the_lock_icon` always uses `Security(APIKEY_AUTH_HEADER)`):** Swagger “lock” + per-operation `security` is emitted only when FastAPI sees a `Security(...)` dependency on the route. Making this dependency unconditional ensures staging endpoints are marked as API-key protected in the OpenAPI output (and therefore in the aggregated swagger), even if the service is started in local mode during tooling/CI. Authentication enforcement still happens via middleware in `CLUSTER_MODE`.