### PR TITLE
Replace asyncache by cachetools-async, update cachetools

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -279,21 +279,6 @@ files = [
 ]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -677,15 +662,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -5587,11 +5587,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"

--- a/services/adgs/poetry.lock
+++ b/services/adgs/poetry.lock
@@ -70,21 +70,6 @@ files = [
 tests = ["mypy (>=1.14.0)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main", "dev"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -416,15 +401,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -3047,11 +3047,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"

--- a/services/cadip/poetry.lock
+++ b/services/cadip/poetry.lock
@@ -70,21 +70,6 @@ files = [
 tests = ["mypy (>=1.14.0)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main", "dev"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -416,15 +401,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -3047,11 +3047,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"

--- a/services/catalog/poetry.lock
+++ b/services/catalog/poetry.lock
@@ -70,21 +70,6 @@ files = [
 tests = ["mypy (>=1.14.0)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main", "dev"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -428,15 +413,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -3328,11 +3328,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"

--- a/services/common/poetry.lock
+++ b/services/common/poetry.lock
@@ -70,21 +70,6 @@ files = [
 tests = ["mypy (>=1.14.0)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -377,15 +362,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -3536,4 +3536,4 @@ tests = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
-content-hash = "640acc9ddc4617563a4e4420eeaacf79edb9841b237510b1d934bd67783406b9"
+content-hash = "2af0091799d8141b2cb9b031be7e5d74b49371de6aed7fc9e1c28d44327709f5"

--- a/services/common/pyproject.toml
+++ b/services/common/pyproject.toml
@@ -66,8 +66,8 @@ python-dotenv = "^1.0.0"
 filelock = ">=3.20.3"
 uvicorn = ">=0.35.0"
 httpx = "^0.28.1"
-cachetools = ">=5.5.2" # idem as stac-fastapi-pgstac
-asyncache = "^0.3.1"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 opentelemetry-distro = "^0.60b1" # then run 'poetry run opentelemetry-bootstrap -a install'
 opentelemetry-instrumentation-aws-lambda = "^0.60b1"
 opentelemetry-test-utils = "^0.60b1"

--- a/services/common/rs_server_common/authentication/apikey.py
+++ b/services/common/rs_server_common/authentication/apikey.py
@@ -27,8 +27,8 @@ from os import environ as env
 from typing import Annotated
 
 import httpx
-from asyncache import cached
 from cachetools import TTLCache
+from cachetools_async import cached
 from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 from rs_server_common import settings

--- a/services/common/rs_server_common/authentication/authentication.py
+++ b/services/common/rs_server_common/authentication/authentication.py
@@ -20,8 +20,8 @@ import os
 from typing import Annotated, Literal
 
 import jwt
-from asyncache import cached
 from cachetools import TTLCache
+from cachetools_async import cached
 from fastapi import HTTPException, Request, Security, status
 from rs_server_common import settings
 from rs_server_common.authentication import oauth2

--- a/services/edrs/poetry.lock
+++ b/services/edrs/poetry.lock
@@ -70,21 +70,6 @@ files = [
 tests = ["mypy (>=1.14.0)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main", "dev"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -365,15 +350,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -2442,11 +2442,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"

--- a/services/osam/poetry.lock
+++ b/services/osam/poetry.lock
@@ -82,21 +82,6 @@ files = [
 ]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main", "dev"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -377,15 +362,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -3460,11 +3460,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"

--- a/services/prip/poetry.lock
+++ b/services/prip/poetry.lock
@@ -70,21 +70,6 @@ files = [
 tests = ["mypy (>=1.14.0)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main", "dev"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -416,15 +401,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -3047,11 +3047,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"

--- a/services/staging/poetry.lock
+++ b/services/staging/poetry.lock
@@ -267,21 +267,6 @@ files = [
 ]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-description = "Helpers to use cachetools with async code."
-optional = false
-python-versions = ">=3.8,<4.0"
-groups = ["main", "dev"]
-files = [
-    {file = "asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5"},
-    {file = "asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035"},
-]
-
-[package.dependencies]
-cachetools = ">=5.2.0,<6.0.0"
-
-[[package]]
 name = "asyncpg"
 version = "0.31.0"
 description = "An asyncio PostgreSQL driver"
@@ -589,15 +574,30 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "7.0.1"
 description = "Extensible memoizing collections and decorators"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
-    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+    {file = "cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf"},
+    {file = "cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341"},
 ]
+
+[[package]]
+name = "cachetools-async"
+version = "0.0.5"
+description = "Provides decorators that are inspired by and work closely with cachetools' for caching asyncio functions and methods."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "cachetools_async-0.0.5-py3-none-any.whl", hash = "sha256:8f690c8bc291718a652395832e90afa797195c838e98d6a9e530dc1de66fbc34"},
+    {file = "cachetools_async-0.0.5.tar.gz", hash = "sha256:e99ec8f3a78e82b4f524e78f01d15b8746531481d862ac4f2d8af2a686e1c571"},
+]
+
+[package.dependencies]
+cachetools = ">=5"
 
 [[package]]
 name = "certifi"
@@ -4744,11 +4744,11 @@ files = []
 develop = true
 
 [package.dependencies]
-asyncache = "^0.3.1"
 authlib = "^1.6.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
-cachetools = ">=5.5.2"
+cachetools = ">=7.0.1"
+cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
 fastapi = "==0.131.0"
 filelock = ">=3.20.3"


### PR DESCRIPTION
asyncache is dead:
- https://github.com/hephex/asyncache/issues/31

and prevents us to update cachetools:
- https://github.com/hephex/asyncache/issues/30

Replace it to https://github.com/imnotjames/cachetools-async instead. Hoping that this project stays maintained.