### PR TITLE
Update to fastapi 0.135.1

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -749,30 +749,19 @@ jobs:
 
       - id: test-demos
         name: "Test rs-demo"
+        env:
+          S3CFG_OVH_BUCKET: ${{ secrets.S3CFG_OVH_BUCKET }}
+          BRANCH_NAME: ${{ needs.set-env.outputs.branch_name }}
+          DOCKER_TAG: ${{ needs.set-env.outputs.docker_tag }}
         run: |
           set -x
 
-          # Copy the s3cmd config file to be able to access the "real" s3 bucket
-          echo "${{ secrets.S3CFG_OVH_BUCKET }}" > ~/.s3cfg
-
           # Clone the rs-demo repository
           git clone https://github.com/RS-PYTHON/rs-demo.git
-
-          # Try to checkout in rs-demo the same branch name than in rs-server.
-          # If the branch doesn't exist, it's ok, we stay on the default branch.
           cd rs-demo
-          git checkout ${{ needs.set-env.outputs.branch_name }} || true
-          git status
 
           # Run the rs-demo local mode using the newly created docker images
-          cd local-mode
-          docker_tag="${{ needs.set-env.outputs.docker_tag }}"
-          docker_tag="${docker_tag:-latest}" # latest by default
-          ./test-docker-tag.sh "$docker_tag"
-          docker compose -f docker-compose-test-tag.yml up cicd -d
-          ./run-notebooks.sh
-          docker compose down -v
-
+          ./test-rs-demo.sh
         shell: bash
 
   ###########################

--- a/poetry.lock
+++ b/poetry.lock
@@ -1439,20 +1439,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -5593,7 +5593,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -5615,7 +5615,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"
@@ -5654,10 +5654,10 @@ develop = true
 
 [package.dependencies]
 attrs = ">=25.3.0,<26.0"
-fastapi = ">=0.123.0"
+fastapi = "==0.135.1"
 pyyaml = "^6.0.2"
 requests = "^2.32.5"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 uvicorn = ">=0.35.0"
 
 [package.source]

--- a/services/adgs/poetry.lock
+++ b/services/adgs/poetry.lock
@@ -970,20 +970,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -3053,7 +3053,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -3075,7 +3075,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"

--- a/services/cadip/poetry.lock
+++ b/services/cadip/poetry.lock
@@ -970,20 +970,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -3053,7 +3053,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -3075,7 +3075,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"

--- a/services/catalog/poetry.lock
+++ b/services/catalog/poetry.lock
@@ -982,20 +982,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -3334,7 +3334,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -3356,7 +3356,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"

--- a/services/common/poetry.lock
+++ b/services/common/poetry.lock
@@ -931,20 +931,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -3536,4 +3536,4 @@ tests = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
-content-hash = "d751d6bae8c5710b2697d98914188161cd501613cd74d16d189da3dd1e2dc3c4"
+content-hash = "85fd869f501da119630e0fa048643a909e737ecec5793366f641ea977f0643c1"

--- a/services/common/pyproject.toml
+++ b/services/common/pyproject.toml
@@ -51,9 +51,9 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4"
-fastapi = "==0.131.0" #">=0.123.0" # TEMPORARY FIX, SHOULD USE THE LATEST VERSION
+fastapi = "==0.135.1"
 jsonpath-ng = "==1.7.0" # TEMPORARY FIX, SHOULD BE REMOVED
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 boto3 = ">=1.40.2"
 botocore = ">=1.40.2"
 sqlalchemy = "^2.0.43"

--- a/services/edrs/poetry.lock
+++ b/services/edrs/poetry.lock
@@ -800,20 +800,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -2448,7 +2448,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -2470,7 +2470,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"

--- a/services/frontend/poetry.lock
+++ b/services/frontend/poetry.lock
@@ -1092,4 +1092,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
-content-hash = "f582a8cd774a979469f750f6e45e3b5317d019b7ea2274f91a20a957e0efa931"
+content-hash = "3bc0c7b8bf2c11d114ee97859a70507977bee4d1ac5cffeb01d62e0ac7c0bc35"

--- a/services/frontend/pyproject.toml
+++ b/services/frontend/pyproject.toml
@@ -52,8 +52,8 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4"
-fastapi = ">=0.123.0"
-starlette = ">=0.49.1,<1"
+fastapi = "==0.135.1"
+starlette = ">=0.49.1"
 uvicorn = ">=0.35.0"
 requests = "^2.32.5"
 attrs = ">=25.3.0,<26.0"

--- a/services/osam/poetry.lock
+++ b/services/osam/poetry.lock
@@ -971,20 +971,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -3466,7 +3466,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -3488,7 +3488,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"

--- a/services/prip/poetry.lock
+++ b/services/prip/poetry.lock
@@ -970,20 +970,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -3053,7 +3053,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -3075,7 +3075,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"

--- a/services/staging/poetry.lock
+++ b/services/staging/poetry.lock
@@ -1318,20 +1318,20 @@ usgs = ["usgs (>=0.3.6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.135.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a"},
-    {file = "fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff"},
+    {file = "fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e"},
+    {file = "fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<1.0.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
 typing-inspection = ">=0.4.2"
 
@@ -4750,7 +4750,7 @@ botocore = ">=1.40.2"
 cachetools = ">=7.0.1"
 cachetools_async = ">=0.0.5"
 eodag = "==v3.10.1"
-fastapi = "==0.131.0"
+fastapi = "==0.135.1"
 filelock = ">=3.20.3"
 geojson-pydantic = "2.1.0"
 httpx = "^0.28.1"
@@ -4772,7 +4772,7 @@ sqlalchemy = "^2.0.43"
 stac-fastapi-pgstac = ">=6.2.0"
 stac-fastapi-types = "^6.2.0"
 stac-pydantic = "^3.4.0"
-starlette = ">=0.49.1,<1"
+starlette = ">=0.49.1"
 urllib3 = ">=2.6.3"
 uvicorn = ">=0.35.0"
 xmltodict = "^1.0.2"

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -398,7 +398,10 @@ class Staging(
                 # If status is not found, create collection body and try to post it.
                 create_response = requests.post(
                     f"{self.catalog_url}/catalog/collections",
-                    headers=self.auth_headers,
+                    headers={
+                        **self.auth_headers,
+                        "Content-Type": "application/json",
+                    },
                     data=dumps(get_minimal_collection_body(catalog_collection)),
                     timeout=5,
                 )
@@ -1098,8 +1101,11 @@ class Staging(
         try:
             response = requests.post(
                 publish_url,
-                headers=self.auth_headers,
-                data=feature.json(),
+                headers={
+                    **self.auth_headers,
+                    "Content-Type": "application/geo+json",
+                },
+                data=feature.model_dump_json(),
                 timeout=10,
             )
             response.raise_for_status()  # Raise an error for HTTP error responses

--- a/services/staging/tests/test_processors/test_staging_catalog.py
+++ b/services/staging/tests/test_processors/test_staging_catalog.py
@@ -182,7 +182,9 @@ class TestStagingPublishCatalog:
     def test_publish_rspy_feature_success(self, mocker, staging_instance: Staging):
         """Test successful feature publishing to the catalog."""
         feature = mocker.Mock()  # Mock the feature object
-        feature.json.return_value = '{"id": "feature1", "properties": {"name": "test"}}'  # Mock the JSON serialization
+        feature.model_dump_json.return_value = (
+            '{"id": "feature1", "properties": {"name": "test"}}'  # Mock the JSON serialization
+        )
         feature.assets = {}
 
         # Mock requests.post to return a successful response
@@ -195,16 +197,16 @@ class TestStagingPublishCatalog:
         assert result is True  # Should return True for successful publishing
         mock_post.assert_called_once_with(
             f"{staging_instance.catalog_url}/catalog/collections/test_collection/items",
-            headers={"cookie": "fake-cookie", APIKEY_HEADER: "fake-api-key"},
-            data=feature.json(),
+            headers={"cookie": "fake-cookie", APIKEY_HEADER: "fake-api-key", "Content-Type": "application/geo+json"},
+            data=feature.model_dump_json(),
             timeout=10,
         )
-        feature.json.assert_called()  # Ensure the feature JSON serialization was called
+        feature.model_dump_json.assert_called()  # Ensure the feature JSON serialization was called
 
     def test_publish_rspy_feature_fail(self, mocker, staging_instance: Staging):
         """Test failure during feature publishing and cleanup on error."""
         feature = mocker.Mock()
-        feature.json.return_value = '{"id": "feature1", "properties": {"name": "test"}}'
+        feature.model_dump_json.return_value = '{"id": "feature1", "properties": {"name": "test"}}'
         feature.assets = {}
 
         for possible_exception in [
@@ -224,8 +226,12 @@ class TestStagingPublishCatalog:
             assert result is False  # Should return False for failure
             mock_post.assert_called_once_with(
                 f"{staging_instance.catalog_url}/catalog/collections/test_collection/items",
-                headers={"cookie": "fake-cookie", APIKEY_HEADER: "fake-api-key"},
-                data=feature.json(),
+                headers={
+                    "cookie": "fake-cookie",
+                    APIKEY_HEADER: "fake-api-key",
+                    "Content-Type": "application/geo+json",
+                },
+                data=feature.model_dump_json(),
                 timeout=10,
             )
             mock_logger.error.assert_called_once_with("Error while publishing items to rspy catalog %s", mocker.ANY)


### PR DESCRIPTION
Update to FastAPI 0.135.1

Adapt to [Strict Content-Type Checking](https://fastapi.tiangolo.com/advanced/strict-content-type/) introduced in FastAPI 0.132.0.

Requires https://github.com/RS-PYTHON/rs-demo/pull/261