### PR TITLE
Update to Python 3.13.12 / Prefect 3.6.20

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON_VERSION: 3.13.11
+  PYTHON_VERSION: 3.13.12
 
 jobs:
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -30,7 +30,7 @@ on:
         required: false
 
 env:
-  PYTHON_VERSION: 3.13.11
+  PYTHON_VERSION: 3.13.12
   DOCKER_REGISTRY: ghcr.io
 
 jobs:

--- a/docs/doc/dev/installation.md
+++ b/docs/doc/dev/installation.md
@@ -37,14 +37,14 @@ Follow instructions from https://github.com/pyenv/pyenv?tab=readme-ov-file#a-get
 ```sh
 # Install the python versions that are used in the project
 pyenv install 3.11.7
-pyenv install 3.13.11
+pyenv install 3.13.12
 
 # Go to the root folder of your rspy project, that contains all you local git repositories
 # and use newest version in all this folder and subfolders
 cd /path/to/parent/rspy
-pyenv local 3.13.11
-# Or if you prefer to use this version everywhere in your system, use: pyenv global 3.13.11
-python -V # should display 3.13.11
+pyenv local 3.13.12
+# Or if you prefer to use this version everywhere in your system, use: pyenv global 3.13.12
+python -V # should display 3.13.12
 
 # WARNING: in rs-dpr-service we still need the old version
 cd rs-dpr-service

--- a/resources/update_framework_versions.sh
+++ b/resources/update_framework_versions.sh
@@ -26,12 +26,12 @@ ROOT_DIR="$(realpath $SCRIPT_DIR/..)"
 # Hardcode here the versions to use, with the same variable names as in the files below
 
 # We use a different python version in eopf + the dpr processors + rs-dpr-service
-PYTHON_VERSION=3.13.11
+PYTHON_VERSION=3.13.12
 PYTHON_VERSION_DPR=3.11.7
 DASK_TAG=2024.5.2
 DASK_GATEWAY_TAG=2024.1.0
-PREFECT_TAG=3.6.12
-PREFECT_AWS_TAG=0.7.1
+PREFECT_TAG=3.6.20
+PREFECT_AWS_TAG=0.7.5
 JUPYTER_HUB_VERSION=5.4.3
 
 # Old version numbers, before we apply this script.
@@ -41,7 +41,7 @@ PYTHON_VERSION_DPR_OLD=3.11.7
 DASK_TAG_OLD=2024.5.2
 DASK_GATEWAY_TAG_OLD=2024.1.0
 PREFECT_TAG_OLD=3.6.12
-PREFECT_AWS_TAG_OLD=0.7.1
+PREFECT_AWS_TAG_OLD=0.7.4
 JUPYTER_HUB_VERSION_OLD=5.4.3
 
 all_variables=(PYTHON_VERSION PYTHON_VERSION_DPR DASK_TAG DASK_GATEWAY_TAG PREFECT_TAG PREFECT_AWS_TAG JUPYTER_HUB_VERSION) # var names
@@ -70,8 +70,6 @@ all_files+=($(_realpath rs-workflow-env/docker/base/Dockerfile.python))
 
 # [local mode] [cluster mode] [ci/cd]
 # + run rs-server ci/cd
-all_files+=($(_realpath operational-services/.github/workflows/check-code-quality.yml))
-all_files+=($(_realpath operational-services/.github/workflows/publish-binaries.yml))
 all_files+=($(_realpath rs-client-libraries/.github/workflows/check-code-quality.yml))
 all_files+=($(_realpath rs-client-libraries/.github/workflows/publish-binaries.yml))
 all_files+=($(_realpath rs-demo/.github/workflows/run_demos.yml))
@@ -83,8 +81,6 @@ all_files+=($(_realpath rs-server/.github/workflows/publish-binaries.yml))
 
 # [local mode] [cluster mode] [docker images]
 # + run rs-server ci/cd
-# [ghcr.io/rs-python/operational-services-osam]
-all_files+=($(_realpath operational-services/object_storage_access_manager/.github/Dockerfile))
 # [ghcr.io/rs-python/rs-dpr-service]
 all_files+=($(_realpath rs-dpr-service/.github/Dockerfile))
 # [ghcr.io/rs-python/rs-server-adgs]
@@ -95,6 +91,8 @@ all_files+=($(_realpath rs-server/services/cadip/.github/Dockerfile))
 all_files+=($(_realpath rs-server/services/catalog/.github/Dockerfile))
 # [ghcr.io/rs-python/rs-server-frontend]
 all_files+=($(_realpath rs-server/services/frontend/.github/Dockerfile))
+# [ghcr.io/rs-python/rs-server-osam]
+all_files+=($(_realpath rs-server/services/osam/.github/Dockerfile))
 # [ghcr.io/rs-python/rs-server-prip]
 all_files+=($(_realpath rs-server/services/prip/.github/Dockerfile))
 # [ghcr.io/rs-python/rs-server-staging]

--- a/services/adgs/.github/Dockerfile
+++ b/services/adgs/.github/Dockerfile
@@ -17,7 +17,7 @@
 # ghcr.io/rs-python/rs-server-adgs
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 
 # Don't use alpine, it's too different from the build stage.
 FROM ghcr.io/rs-python/python:${PYTHON_VERSION}-slim-bookworm

--- a/services/cadip/.github/Dockerfile
+++ b/services/cadip/.github/Dockerfile
@@ -17,7 +17,7 @@
 # ghcr.io/rs-python/rs-server-cadip
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 
 # Don't use alpine, it's too different from the build stage.
 FROM ghcr.io/rs-python/python:${PYTHON_VERSION}-slim-bookworm

--- a/services/catalog/.github/Dockerfile
+++ b/services/catalog/.github/Dockerfile
@@ -17,7 +17,7 @@
 # ghcr.io/rs-python/rs-server-catalog
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 
 # Don't use alpine, it's too different from the build stage.
 FROM ghcr.io/rs-python/python:${PYTHON_VERSION}-slim-bookworm

--- a/services/frontend/.github/Dockerfile
+++ b/services/frontend/.github/Dockerfile
@@ -17,7 +17,7 @@
 # ghcr.io/rs-python/rs-server-frontend
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 
 # Build stage for multi stage build.
 FROM ghcr.io/rs-python/python:${PYTHON_VERSION}-slim-bookworm

--- a/services/osam/.github/Dockerfile
+++ b/services/osam/.github/Dockerfile
@@ -17,7 +17,7 @@
 # ghcr.io/rs-python/operational-services-osam
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 
 # Don't use alpine, it's too different from the build stage.
 FROM ghcr.io/rs-python/python:${PYTHON_VERSION}-slim-bookworm AS builder

--- a/services/prip/.github/Dockerfile
+++ b/services/prip/.github/Dockerfile
@@ -17,7 +17,7 @@
 # ghcr.io/rs-python/rs-server-prip
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 
 # Don't use alpine, it's too different from the build stage.
 FROM ghcr.io/rs-python/python:${PYTHON_VERSION}-slim-bookworm

--- a/services/staging/.github/Dockerfile
+++ b/services/staging/.github/Dockerfile
@@ -17,7 +17,7 @@
 # ghcr.io/rs-python/rs-server-staging
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 
 # Build stage for multi stage build.
 FROM ghcr.io/rs-python/python:${PYTHON_VERSION}-slim-bookworm AS builder

--- a/services/staging/.github/Dockerfile.dask-staging
+++ b/services/staging/.github/Dockerfile.dask-staging
@@ -18,7 +18,7 @@
 # ghcr.io/rs-python/dask/staging
 #
 
-ARG PYTHON_VERSION=3.13.11
+ARG PYTHON_VERSION=3.13.12
 ARG DASK_GATEWAY_TAG=2024.1.0
 
 FROM ghcr.io/rs-python/dask/dask-gateway:${DASK_GATEWAY_TAG}-py${PYTHON_VERSION}


### PR DESCRIPTION
Update Python to:
- https://www.python.org/downloads/release/python-31312/

Update Prefect to:
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.13
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.14
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.15
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.16
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.17
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.18
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.19
- https://github.com/PrefectHQ/prefect/releases/tag/3.6.20

Pull requests:
- https://github.com/RS-PYTHON/rs-server/pull/1791
- https://github.com/RS-PYTHON/rs-client-libraries/pull/221
- https://github.com/RS-PYTHON/rs-demo/pull/264
- https://github.com/RS-PYTHON/rs-infra-core/pull/301
- https://github.com/RS-PYTHON/rs-server-deployment/pull/58
- https://github.com/RS-PYTHON/rs-testmeans/pull/99
- https://github.com/RS-PYTHON/rs-workflow-env/pull/68