### PR TITLE
Add anchor links to sub-sections in the frontend swagger

### DIFF
--- a/services/frontend/resources/services.yml
+++ b/services/frontend/resources/services.yml
@@ -32,14 +32,14 @@ info:
     <a href="https://home.rs-python.eu/rs-documentation/" target="_blank">Documentation</a> /
     <a href="${RSPY_UAC_HOMEPAGE}" target="_blank">API-Key Manager</a>
     <br><br>
-    <a href="#/ADGS%20stations">ADGS stations</a> /
-    <a href="#/CADIP%20stations">CADIP stations</a> /
-    <a href="#/PRIP%20stations">PRIP stations</a> /
-    <a href="#/EDRS%20stations">EDRS stations</a> /
-    <a href="#/OSAM%20service">OSAM service</a> /
-    <a href="#/Catalog">Catalog</a> /
-    <a href="#/Staging%20service">Staging service</a> /
-    <a href="#/Processing%20service">Processing service</a>
+    <a href="#/ADGS%20stations" target="_blank">ADGS stations</a> /
+    <a href="#/CADIP%20stations" target="_blank">CADIP stations</a> /
+    <a href="#/PRIP%20stations" target="_blank">PRIP stations</a> /
+    <a href="#/EDRS%20stations" target="_blank">EDRS stations</a> /
+    <a href="#/OSAM%20service" target="_blank">OSAM service</a> /
+    <a href="#/Catalog" target="_blank">Catalog</a> /
+    <a href="#/Staging%20service" target="_blank">Staging service</a> /
+    <a href="#/Processing%20service" target="_blank">Processing service</a>
 
     ---
     #### STAC Browser

--- a/services/frontend/resources/services.yml
+++ b/services/frontend/resources/services.yml
@@ -30,7 +30,16 @@ info:
 
     <a href="https://home.rs-python.eu/" target="_blank">Website</a> /
     <a href="https://home.rs-python.eu/rs-documentation/" target="_blank">Documentation</a> /
-    <a href="${RSPY_UAC_HOMEPAGE}" target="_blank">API-Key Manager</a> /
+    <a href="${RSPY_UAC_HOMEPAGE}" target="_blank">API-Key Manager</a>
+    <br><br>
+    <a href="#/ADGS%20stations">ADGS stations</a> /
+    <a href="#/CADIP%20stations">CADIP stations</a> /
+    <a href="#/PRIP%20stations">PRIP stations</a> /
+    <a href="#/EDRS%20stations">EDRS stations</a> /
+    <a href="#/OSAM%20service">OSAM service</a> /
+    <a href="#/Catalog">Catalog</a> /
+    <a href="#/Staging%20service">Staging service</a> /
+    <a href="#/Processing%20service">Processing service</a>
 
     ---
     #### STAC Browser


### PR DESCRIPTION
The swagger page is becoming quite big, so at the top of it, I'm adding some links to the internal subsections (in the red frame below):

<img width="1440" height="923" alt="image" src="https://github.com/user-attachments/assets/51ced5fc-9380-4378-b898-a444fd4b27aa" />

So for example we have
```
<a href="#/CADIP%20stations">CADIP stations</a>
```
and clicking on this link opens a new tab and takes you a little below on the right section.

NOTE: I tried to make it work without opening a new tab (without the `target="_blank"`) but it doesn't work, nothing happens when we click with the left button of the mouse. It works with the middle button (this opens a new tab).

I think it's due to https://github.com/swagger-api/swagger-ui/issues/3958

Nicolas told me to switch the # and / order in the link: opening the url `/#CADIP%20stations` (instead of `#/CADIP%20stations`) works in the same page. But it doesn't work in local mode with the docker compose, because the nginx redirection does not seem to handle it well. I've not tried to integrate it properly in cluster mode. I've just gave it up because it's not a high priority.
