### PR TITLE
RSPY1012: Improved catalog publication

### DIFF
--- a/services/catalog/rs_server_catalog/data_management/s3_manager.py
+++ b/services/catalog/rs_server_catalog/data_management/s3_manager.py
@@ -16,6 +16,7 @@
 
 import os
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 
 import botocore
 from fastapi import HTTPException
@@ -35,6 +36,8 @@ from starlette.status import (
 )
 
 PRESIGNED_URL_EXPIRATION_TIME = int(os.environ.get("RSPY_PRESIGNED_URL_EXPIRATION_TIME", "1800"))  # 30 minutes
+# Max number of parallel threads when checking asset existence on S3 during publication
+PUBLISH_CHECK_MAX_WORKERS = int(os.environ.get("RSPY_S3_PUBLISH_CHECK_MAX_WORKERS", "6"))
 
 logger = Logging.default(__name__)
 
@@ -266,21 +269,46 @@ class S3Manager:
         item_eopf_type = content["properties"].get("eopf:type", "")
         bucket_name = get_bucket_name_from_config(user, collection_id, item_eopf_type)
         exist_list = []
+        assets_to_check = []
+
+        # First do the cheap validations locally so we avoid scheduling S3 calls for
+        # assets that are already invalid from the STAC payload itself.
         for asset_name, asset_info in content.get("assets", {}).items():
-            exists = False
-            if s3_key := asset_info.get("href"):
-                if bucket_name not in s3_key:
-                    logger.error(
-                        f"Asset: {asset_name}, The s3 key {s3_key} should contain the bucket name {bucket_name}",
-                    )
-                    exist_list.append(False)
-                    continue
-                try:
-                    exists, size = self.check_s3_key(content, asset_name, s3_key)
-                    logger.info(f"Asset: {asset_name}, Found on bucket: {exists}, Size: {size}")
-                except HTTPException as e:
-                    logger.error(f"Asset: {asset_name}, Error: {e.detail}")
-            else:
+            if not (s3_key := asset_info.get("href")):
                 logger.error(f"Asset: {asset_name}, No href key found for this asset")
-            exist_list.append(exists)
+                exist_list.append(False)
+                continue
+
+            # We only allow publication from the bucket resolved from the item metadata.
+            # If the href points to a different bucket, we can reject it immediately.
+            if bucket_name not in s3_key:
+                logger.error(
+                    f"Asset: {asset_name}, The s3 key {s3_key} should contain the bucket name {bucket_name}",
+                )
+                exist_list.append(False)
+                continue
+
+            # Keep only the assets that require a real S3 existence check.
+            assets_to_check.append((asset_name, s3_key))
+
+        def _check_asset(asset: tuple[str, str]) -> bool:
+            # This helper runs inside the thread pool so each asset can be checked
+            # independently without blocking the whole publication flow.
+            asset_name, s3_key = asset
+            try:
+                exists, size = self.check_s3_key(content, asset_name, s3_key)
+                logger.info(f"Asset: {asset_name}, Found on bucket: {exists}, Size: {size}")
+                return exists
+            except HTTPException as e:
+                logger.error(f"Asset: {asset_name}, Error: {e.detail}")
+                return False
+
+        if assets_to_check:
+            # boto3 does not provide a generic bulk "exists" API for arbitrary keys,
+            # so the best low-risk optimization here is to fan out the checks in parallel.
+            # The number of workers is capped to avoid overwhelming the S3 endpoint.
+            max_workers = min(len(assets_to_check), max(1, PUBLISH_CHECK_MAX_WORKERS))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                exist_list.extend(executor.map(_check_asset, assets_to_check))
+
         return all(exist_list)

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -1095,7 +1095,8 @@ class Staging(
         for asset in feature.assets.values():
             if hasattr(asset, "alternate"):
                 del asset.alternate  # type: ignore
-        for attempt in range(self.catalog_publish_max_retries + 1):
+        attempt = 0
+        while attempt <= self.catalog_publish_max_retries:
             try:
                 response = requests.post(
                     publish_url,
@@ -1119,6 +1120,7 @@ class Staging(
                     self.catalog_publish_retry_delay,
                 )
                 time.sleep(self.catalog_publish_retry_delay)
+                attempt += 1
             except (RequestException, JSONDecodeError) as exc:
                 self.logger.error("Error while publishing items to rspy catalog %s", exc)
                 return False

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -154,7 +154,7 @@ class Staging(
         )  # get catalog href, loopback else
         self.catalog_publish_timeout: int = int(os.environ.get("RSPY_CATALOG_PUBLISH_TIMEOUT", "120"))
         self.catalog_publish_max_retries: int = int(os.environ.get("RSPY_CATALOG_PUBLISH_MAX_RETRIES", "3"))
-        self.catalog_publish_retry_delay: float = float(os.environ.get("RSPY_CATALOG_PUBLISH_RETRY_DELAY", "1"))
+        self.catalog_publish_retry_delay: float = float(os.environ.get("RSPY_CATALOG_PUBLISH_RETRY_DELAY", "30"))
         self.staging_user: str = "staging_user"
         #################
         # Database section

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -152,6 +152,9 @@ class Staging(
             "RSPY_HOST_CATALOG",
             "http://127.0.0.1:8003",
         )  # get catalog href, loopback else
+        self.catalog_publish_timeout: int = int(os.environ.get("RSPY_CATALOG_PUBLISH_TIMEOUT", "120"))
+        self.catalog_publish_max_retries: int = int(os.environ.get("RSPY_CATALOG_PUBLISH_MAX_RETRIES", "3"))
+        self.catalog_publish_retry_delay: float = float(os.environ.get("RSPY_CATALOG_PUBLISH_RETRY_DELAY", "1"))
         self.staging_user: str = "staging_user"
         #################
         # Database section
@@ -1092,21 +1095,35 @@ class Staging(
         for asset in feature.assets.values():
             if hasattr(asset, "alternate"):
                 del asset.alternate  # type: ignore
-        try:
-            response = requests.post(
-                publish_url,
-                headers={
-                    **self.auth_headers,
-                    "Content-Type": "application/geo+json",
-                },
-                data=feature.model_dump_json(),
-                timeout=10,
-            )
-            response.raise_for_status()  # Raise an error for HTTP error responses
-            return True
-        except (RequestException, JSONDecodeError) as exc:
-            self.logger.error("Error while publishing items to rspy catalog %s", exc)
-            return False
+        for attempt in range(self.catalog_publish_max_retries + 1):
+            try:
+                response = requests.post(
+                    publish_url,
+                    headers={
+                        **self.auth_headers,
+                        "Content-Type": "application/geo+json",
+                    },
+                    data=feature.model_dump_json(),
+                    timeout=self.catalog_publish_timeout,
+                )
+                response.raise_for_status()  # Raise an error for HTTP error responses
+                return True
+            except requests.exceptions.Timeout as exc:
+                if attempt >= self.catalog_publish_max_retries:
+                    self.logger.error("Error while publishing items to rspy catalog %s", exc)
+                    return False
+                self.logger.warning(
+                    "Timeout while publishing items to rspy catalog. Retry %s/%s in %ss",
+                    attempt + 1,
+                    self.catalog_publish_max_retries,
+                    self.catalog_publish_retry_delay,
+                )
+                time.sleep(self.catalog_publish_retry_delay)
+            except (RequestException, JSONDecodeError) as exc:
+                self.logger.error("Error while publishing items to rspy catalog %s", exc)
+                return False
+
+        return False
 
     def unpublish_rspy_features(self, catalog_collection: str, feature_ids: list[str]):
         """Deletes specified features from the RSPy catalog by sending DELETE requests to the

--- a/services/staging/tests/test_processors/test_staging_catalog.py
+++ b/services/staging/tests/test_processors/test_staging_catalog.py
@@ -202,7 +202,7 @@ class TestStagingPublishCatalog:
             f"{staging_instance.catalog_url}/catalog/collections/test_collection/items",
             headers={"cookie": "fake-cookie", APIKEY_HEADER: "fake-api-key", "Content-Type": "application/geo+json"},
             data=feature.model_dump_json(),
-            timeout=10,
+            timeout=staging_instance.catalog_publish_timeout,
         )
         feature.model_dump_json.assert_called()  # Ensure the feature JSON serialization was called
 
@@ -214,7 +214,6 @@ class TestStagingPublishCatalog:
 
         for possible_exception in [
             requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
             requests.exceptions.RequestException,
             requests.exceptions.ConnectionError,
         ]:
@@ -235,9 +234,55 @@ class TestStagingPublishCatalog:
                     "Content-Type": "application/geo+json",
                 },
                 data=feature.model_dump_json(),
-                timeout=10,
+                timeout=staging_instance.catalog_publish_timeout,
             )
             mock_logger.error.assert_called_once_with("Error while publishing items to rspy catalog %s", mocker.ANY)
+
+    def test_publish_rspy_feature_timeout_retry_success(self, mocker, staging_instance: Staging):
+        """Test that a timeout is retried before succeeding."""
+        feature = mocker.Mock()
+        feature.model_dump_json.return_value = '{"id": "feature1", "properties": {"name": "test"}}'
+        feature.assets = {}
+
+        mock_response = mocker.Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_post = mocker.patch(
+            "requests.post",
+            side_effect=[requests.exceptions.Timeout("timeout"), mock_response],
+        )
+        mock_sleep = mocker.patch("time.sleep")
+        mock_logger = mocker.patch.object(staging_instance, "logger")
+
+        result = staging_instance.publish_rspy_feature("test_collection", feature)
+
+        assert result is True
+        assert mock_post.call_count == 2
+        mock_sleep.assert_called_once_with(staging_instance.catalog_publish_retry_delay)
+        mock_logger.warning.assert_called_once_with(
+            "Timeout while publishing items to rspy catalog. Retry %s/%s in %ss",
+            1,
+            staging_instance.catalog_publish_max_retries,
+            staging_instance.catalog_publish_retry_delay,
+        )
+        mock_logger.error.assert_not_called()
+
+    def test_publish_rspy_feature_timeout_retry_exhausted(self, mocker, staging_instance: Staging):
+        """Test that staging gives up after the configured number of timeout retries."""
+        feature = mocker.Mock()
+        feature.model_dump_json.return_value = '{"id": "feature1", "properties": {"name": "test"}}'
+        feature.assets = {}
+
+        timeout_error = requests.exceptions.Timeout("HTTP Error occurred")
+        mock_post = mocker.patch("requests.post", side_effect=timeout_error)
+        mock_sleep = mocker.patch("time.sleep")
+        mock_logger = mocker.patch.object(staging_instance, "logger")
+
+        result = staging_instance.publish_rspy_feature("test_collection", feature)
+
+        assert result is False
+        assert mock_post.call_count == staging_instance.catalog_publish_max_retries + 1
+        assert mock_sleep.call_count == staging_instance.catalog_publish_max_retries
+        mock_logger.error.assert_called_once_with("Error while publishing items to rspy catalog %s", mocker.ANY)
 
     def test_repr(self, staging_instance: Staging):
         """Test repr method for coverage"""


### PR DESCRIPTION
**rs-server-catalog:**

Added configurable threading for S3 asset checks. The number of worker threads can be controlled via `RSPY_S3_PUBLISH_CHECK_MAX_WORKERS` (default: 6).
Note: The optimal value may depend on the cloud provider's limits for parallel requests.

**rs-server-staging:**

Added a configurable retry mechanism for publishing items to the catalog.

* `RSPY_CATALOG_PUBLISH_TIMEOUT` – timeout (in seconds) after which the staging process stops if the catalog does not respond.
* `RSPY_CATALOG_PUBLISH_MAX_RETRIES` – maximum number of retry attempts for publishing an item.
* `RSPY_CATALOG_PUBLISH_RETRY_DELAY` – delay (in seconds) between retry attempts.
