### PR TITLE
RSPY-1028 - Use Links model from stac_pydantic

### DIFF
--- a/services/staging/rs_server_staging/utils/rspy_models.py
+++ b/services/staging/rs_server_staging/utils/rspy_models.py
@@ -16,6 +16,7 @@
 from typing import Any
 
 from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
+from stac_pydantic.links import Links
 from stac_pydantic.shared import Asset  # Importing directly for clarity
 
 
@@ -40,8 +41,7 @@ class Feature(BaseModel):
         stac_version (str): The version of the STAC specification used.
         assets (Dict[str, Asset]): A dictionary of assets associated with the feature.
             Keys are asset names, and values are `Asset` objects.
-        links (Optional[List[Dict[str, str]]]): A list of link dictionaries, where each
-            dictionary represents a link related to the feature. Defaults to None.
+        links (Optional[Links]): A list of links related to the feature. Defaults to None.
         stac_extensions (List[str]): A list of STAC extension URIs used in this feature.
     """
 
@@ -52,7 +52,7 @@ class Feature(BaseModel):
     id: str
     stac_version: str
     assets: dict[str, Asset]
-    links: list[dict[str, str]] | None = None
+    links: Links | None = None
     stac_extensions: list[str]
 
 

--- a/services/staging/tests/resources/sample_data.py
+++ b/services/staging/tests/resources/sample_data.py
@@ -96,7 +96,14 @@ sample_process_metadata_model = {
                             },
                         },
                         "links": [
-                            {"additionalProp1": "string", "additionalProp2": "string", "additionalProp3": "string"},
+                            {
+                                "rel": "enclosure",
+                                "href": "s3://eodata/Sentinel-1/SAR/IW_SLC__1S/2026/04/14/S1A_IW_SLC__1SDV_20260414T174721_20260414T174748_064079_08103D_4998.SAFE/",  # noqa: E501 # pylint: disable=line-too-long
+                                "type": "application/x-directory",
+                                "title": "S3 path to source directory",
+                                "auth:refs": ["s3"],
+                                "storage:refs": ["cdse-s3", "creodias-s3"],
+                            },
                         ],
                         "stac_extensions": ["string"],
                     },


### PR DESCRIPTION
To allow staging data from CDSE:

https://stac.dataspace.copernicus.eu/v1/collections/sentinel-1-slc/items?datetime=2026-04-01T00%3A00%3A00.000Z%2F2026-04-30T00%3A00%3A00.000Z&bbox=1.49319102647564%2C43.55965105873602%2C1.5043201542126%2C43.5629914174788&limit=6&sortby=-properties.created

Which uses this kind of links:

```json
        {
          "rel": "enclosure",
          "href": "s3://eodata/Sentinel-1/SAR/IW_SLC__1S/2026/04/14/S1A_IW_SLC__1SDV_20260414T174721_20260414T174748_064079_08103D_4998.SAFE/",
          "type": "application/x-directory",
          "title": "S3 path to source directory",
          "auth:refs": [
            "s3"
          ],
          "storage:refs": [
            "cdse-s3",
            "creodias-s3"
          ]
        },
```

our current too simple model causes Pydantic validation errors:

```
	2026-04-15T14:50:46.596Z	  features.5.links.4.storage:refs
	2026-04-15T14:50:46.596Z	      For further information visit https://errors.pydantic.dev/2.12/v/string_type
	2026-04-15T14:50:46.596Z	    Input should be a valid string [type=string_type, input_value=['s3'], input_type=list]
	2026-04-15T14:50:46.596Z	  features.5.links.4.auth:refs
	2026-04-15T14:50:46.596Z	      For further information visit https://errors.pydantic.dev/2.12/v/string_type
	2026-04-15T14:50:46.596Z	    Input should be a valid string [type=string_type, input_value=['cdse-s3', 'creodias-s3'], 
```