### PR TITLE
RSPY-1121: Fix duplicated asset when staging with named assets

### DIFF
--- a/services/staging/rs_server_staging/processors/tasks.py
+++ b/services/staging/rs_server_staging/processors/tasks.py
@@ -212,7 +212,8 @@ def prepare_streaming_tasks(
 
     assets_info: list[AssetInfo] = []
 
-    for asset_name, asset_content in list(feature.assets.items()):
+    for original_asset_name, asset_content in list(feature.assets.items()):
+        asset_name = original_asset_name
         if not asset_content.href or not asset_name:
             logger.error("Missing href or title in asset dictionary")
             return None
@@ -254,6 +255,10 @@ def prepare_streaming_tasks(
         # Mutate the feature in place so the later catalog POST/PUT references
         # the object that the Dask task is about to create.
         asset_content.href = f"s3://{s3_bucket_name}/{s3_obj_path}"
+        if asset_name != original_asset_name:
+            # The asset was renamed to its file:local_path: drop the original
+            # key so the asset is not published twice under both names.
+            del feature.assets[original_asset_name]
         feature.assets[asset_name] = asset_content
     logger.info("Prepared %d streaming task(s) for feature %s", len(assets_info), feature.id)
     return assets_info

--- a/services/staging/tests/test_processors/test_streaming.py
+++ b/services/staging/tests/test_processors/test_streaming.py
@@ -277,6 +277,43 @@ class TestPrepareStreaming:
         assert feature.assets["asset1"].href == f"s3://{bucket}/staging_user/{catalog_collection}/{feature.id}/asset1"
         assert feature.assets["asset2"].href == f"s3://{bucket}/staging_user/{catalog_collection}/{feature.id}/asset2"
 
+    def test_prepare_streaming_tasks_named_assets_no_duplicate(self, mocker):
+        """Test that with named_assets=True, an asset renamed to its file:local_path
+        replaces the original asset key instead of being duplicated."""
+        catalog_collection = "test_collection"
+        feature = mocker.Mock()
+        feature.id = "feature_id"
+        feature.properties = {}
+        local_path = "S1D_IW_ETA__AXDV_feature.SAFE.zip"
+        feature.assets = {
+            "product": Asset(**{"href": "https://example.com/product", "file:local_path": local_path}),
+            "thumbnail": Asset(href="https://example.com/thumbnail"),
+        }
+
+        result = prepare_streaming_tasks(catalog_collection, feature, "staging_user", named_assets=True)
+
+        bucket = "rspython-ops-catalog-all-production"
+        expected_assets_info = [
+            AssetInfo(
+                "https://example.com/product",
+                f"staging_user/{catalog_collection}/{feature.id}/{local_path}",
+                bucket,
+            ),
+            AssetInfo(
+                "https://example.com/thumbnail",
+                f"staging_user/{catalog_collection}/{feature.id}/thumbnail",
+                bucket,
+            ),
+        ]
+        assert result == expected_assets_info
+
+        # The renamed asset must replace the original key: no duplicated asset
+        assert set(feature.assets.keys()) == {local_path, "thumbnail"}
+        assert (
+            feature.assets[local_path].href
+            == f"s3://{bucket}/staging_user/{catalog_collection}/{feature.id}/{local_path}"
+        )
+
     def test_prepare_streaming_tasks_with_s3_asset_all_valid(self, mocker):
         """Test prepare_streaming_tasks when all assets are valid and one asset needs to be staged from external s3."""
         # Patch credentials retrieval (for s3 asset)


### PR DESCRIPTION
When named_assets is enabled, the asset renamed to its file:local_path was re-inserted into the feature assets under the new key while the original key (e.g. 'product') was kept, so the item was published in the catalog with the same asset twice. Remove the original key when the asset is renamed.