### PR TITLE
RSPY-1038 Improve OpenTelemetry staging support

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -388,6 +388,14 @@ jobs:
           # Run the rs-demo local mode using the newly created docker images
           ./test-rs-demo.sh
 
+      - name: Upload executed notebooks
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: notebook-outputs
+          path: local-mode/notebook-outputs/
+          if-no-files-found: ignore
+
       # If we used a temp docker tag, and only if the tests succeeded, then
       # we tag the images with the real tags and push them.
       - name: Tag and push Docker images

--- a/services/common/rs_server_common/s3_storage_handler/s3_storage_handler.py
+++ b/services/common/rs_server_common/s3_storage_handler/s3_storage_handler.py
@@ -1141,20 +1141,21 @@ retried for %s times. Aborting",
                         )
                     self.logger.info(f"Successfully uploaded to s3://{bucket}/{key}")
                     break
-        except (
-            requests.exceptions.RequestException,
-            botocore.client.ClientError,
-            botocore.exceptions.BotoCoreError,
-        ) as e:
-            self.logger.exception(f"Failed to stream the file from {request.url} to s3://{bucket}/{key}: {e}.")
-            raise ConnectionError(f"Failed to stream the file from {request.url} to s3://{bucket}/{key}: {e}.") from e
         except Exception as e:
-            self.logger.exception(
-                f"General exception.\nFailed to stream the file from {request.url} to s3://{bucket}/{key}: {e}",
-            )
-            raise RuntimeError(
-                f"General exception.\nFailed to stream the file from {request.url} to s3://{bucket}/{key}: {e}",
-            ) from e
+            message = f"Failed to stream the file from {request.url} to s3://{bucket}/{key}: {traceback.format_exc()}"
+
+            connection_error = type(e) in [
+                requests.exceptions.RequestException,
+                botocore.client.ClientError,
+                botocore.exceptions.BotoCoreError,
+            ]
+            if not connection_error:
+                message = f"General exception.\n{message}"
+
+            self.logger.exception(message)
+            if connection_error:
+                raise ConnectionError(message) from e
+            raise RuntimeError(message) from e
 
     def s3_streaming_from_http(
         self,

--- a/services/common/rs_server_common/s3_storage_handler/s3_storage_handler.py
+++ b/services/common/rs_server_common/s3_storage_handler/s3_storage_handler.py
@@ -1144,11 +1144,14 @@ retried for %s times. Aborting",
         except Exception as e:
             message = f"Failed to stream the file from {request.url} to s3://{bucket}/{key}: {traceback.format_exc()}"
 
-            connection_error = type(e) in [
-                requests.exceptions.RequestException,
-                botocore.client.ClientError,
-                botocore.exceptions.BotoCoreError,
-            ]
+            connection_error = isinstance(
+                e,
+                (
+                    requests.exceptions.RequestException,
+                    botocore.client.ClientError,
+                    botocore.exceptions.BotoCoreError,
+                ),
+            )
             if not connection_error:
                 message = f"General exception.\n{message}"
 

--- a/services/common/tests/s3_storage_handler/test_s3_storage_handler_err.py
+++ b/services/common/tests/s3_storage_handler/test_s3_storage_handler_err.py
@@ -83,6 +83,8 @@ def test_get_keys_from_s3_download_fail(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
     requests.post("http://localhost:5001/moto-api/reset", timeout=5)
+
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
 
     config = GetKeysFromS3Config(
@@ -142,6 +144,8 @@ def test_put_files_to_s3_upload_fail(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
     requests.post("http://localhost:5001/moto-api/reset", timeout=5)
+
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
 
     config = PutFilesToS3Config(
@@ -185,6 +189,8 @@ def test_transfer_from_s3_to_s3_fail(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
     requests.post("http://localhost:5001/moto-api/reset", timeout=5)
+
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     s3_handler.s3_client.create_bucket(Bucket=bucket_src)
     s3_handler.s3_client.create_bucket(Bucket=bucket_src)
@@ -249,6 +255,8 @@ def test_delete_key_from_s3_fail(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
     requests.post("http://localhost:5001/moto-api/reset", timeout=5)
+
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     # test when there is no file to be deleted
     with pytest.raises(RuntimeError) as exc:
@@ -327,6 +335,7 @@ def test_s3_streaming_upload_fail(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
 
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     # prepare a bucket for tests
     bucket = "s3-bucket-streaming"
@@ -387,6 +396,7 @@ def test_check_s3_key_on_bucket_forbidden(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
 
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     # prepare a bucket for tests
     bucket = "some_s3"
@@ -413,6 +423,7 @@ def test_check_s3_key_on_bucket_not_found(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
 
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     # prepare a bucket for tests
     bucket = "some_s3"
@@ -443,6 +454,7 @@ def test_check_s3_key_on_bucket_unchecked_client_error(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
 
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     # prepare a bucket for tests
     bucket = "some_s3"
@@ -473,6 +485,7 @@ def test_check_s3_key_on_bucket_unchecked_client_error(mocker):
 
 def test_check_s3_key_on_bucket_connection_error(mocker):
     """Test case for connection error when accessing S3 bucket."""
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     bucket = "some_s3"
     s3_key = "test_key.tst"
@@ -498,6 +511,7 @@ def test_check_s3_key_on_bucket_general_exception(mocker):
     server = ThreadedMotoServer(port=5001)
     server.start()
 
+    export_aws_credentials()
     s3_handler = S3StorageHandler(S3Credentials(None, None, "http://localhost:5001", ""))
     bucket = "some_s3"
     s3_handler.s3_client.create_bucket(Bucket=bucket)

--- a/services/frontend/resources/openapi.json
+++ b/services/frontend/resources/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "RS-Server",
-    "version": "1.0a11",
+    "version": "1.0a12",
     "description": "\nThe Copernicus Space Component Reference System is an open-source software solution allowing to implement,\nmaintain, deploy, operate and monitor Sentinel data processing workflows based on the future re-engineered Level\n0, 1, 2 Sentinel Data processors (Q3 2024/2025).\n\n---\n#### OAuth 2.0 authentication\n\n<a href=\"/auth/login\" target=\"_self\">Login</a> /\n<a href=\"/auth/logout\" target=\"_blank\">Logout</a>\n\n---\n#### Links\n\n<a href=\"https://home.rs-python.eu/\" target=\"_blank\">Website</a> /\n<a href=\"https://home.rs-python.eu/rs-documentation/\" target=\"_blank\">Documentation</a> /\n<a href=\"${RSPY_UAC_HOMEPAGE}\" target=\"_blank\">API-Key Manager</a>\n<br><br>\n<a href=\"#/ADGS%20stations\" target=\"_blank\">ADGS stations</a> /\n<a href=\"#/CADIP%20stations\" target=\"_blank\">CADIP stations</a> /\n<a href=\"#/PRIP%20stations\" target=\"_blank\">PRIP stations</a> /\n<a href=\"#/OSAM%20service\" target=\"_blank\">OSAM service</a> /\n<a href=\"#/Catalog\" target=\"_blank\">Catalog</a> /\n<a href=\"#/Staging%20service\" target=\"_blank\">Staging service</a> /\n<a href=\"#/Processing%20service\" target=\"_blank\">Processing service</a>\n\n---\n#### STAC Browser\n\n<a href=\"${STAC_BROWSER_URL_ADGS}\" target=\"_blank\">ADGS</a> /\n<a href=\"${STAC_BROWSER_URL_CADIP}\" target=\"_blank\">CADIP</a> /\n<a href=\"${STAC_BROWSER_URL_PRIP}\" target=\"_blank\">PRIP</a> /\n<a href=\"${STAC_BROWSER_URL_CATALOG}\" target=\"_blank\">Catalog</a>\n\n---\n"
   },
   "paths": {
@@ -6513,6 +6513,46 @@
             "schema": {
               "type": "string",
               "title": "Resource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dpr/jobs/{job_id}/logs": {
+      "get": {
+        "tags": [
+          "Processing service"
+        ],
+        "summary": "Get Job Logs Endpoint",
+        "description": "Used to stream logs of a processing job.",
+        "operationId": "get_job_logs_endpoint_dpr_jobs__job_id__logs_get",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "title": "Job Id"
             }
           }
         ],

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -1377,7 +1377,7 @@ class Staging(
         try:
             with init_opentelemetry.start_span(
                 __name__,
-                f"[{self.staging_user}:{catalog_collection}] manage_dask_tasks",
+                f"[{self.staging_user}:{catalog_collection}] staging_dask_tasks",
             ):
                 await asyncio.to_thread(
                     self.manage_dask_tasks,

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -906,18 +906,6 @@ class Staging(
         # Prepare environment to trace dask tasks with opentelemetry.
         task_env = self._prepare_env_with_trace_context(catalog_collection)
 
-        # # TEMP !!
-        # from importlib import reload
-        # import sys
-        # def reload_uploaded():
-        #     reloaded = []
-        #     for module in list(sys.modules.values()):
-        #         if "rs_server" in module.__name__:
-        #             reload(module)
-        #             reloaded.append(module.__name__)
-        #     return f"Reloaded: {reloaded}"
-        # self.logger.debug(json.dumps(client.run(reload_uploaded), indent=2))
-
         # prevent submitting more tasks than necessary.
         # this can occur when the number of tasks that can run in parallel
         # exceeds the actual number of tasks intended for submission.
@@ -1387,7 +1375,10 @@ class Staging(
         # loop remains responsive while `as_completed` waits for task results.
         self.logger.debug("Starting tasks monitoring thread")
         try:
-            with init_opentelemetry.start_span(__name__, f"[{catalog_collection}] manage_dask_tasks"):
+            with init_opentelemetry.start_span(
+                __name__,
+                f"[{self.staging_user}:{catalog_collection}] manage_dask_tasks",
+            ):
                 await asyncio.to_thread(
                     self.manage_dask_tasks,
                     dask_client,

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -904,7 +904,7 @@ class Staging(
         self.logger.debug("Retrieved S3 credentials object for job %s", self.job_id)
 
         # Prepare environment to trace dask tasks with opentelemetry.
-        task_env = self._prepare_env_with_trace_context(catalog_collection)
+        task_env = self._prepare_env_with_trace_context()
 
         # prevent submitting more tasks than necessary.
         # this can occur when the number of tasks that can run in parallel
@@ -978,7 +978,7 @@ class Staging(
         self.unsubscribe_refresh_tokens(refresh_tokens)
         self.logger.info("Tasks monitoring finished")
 
-    def _prepare_env_with_trace_context(self, catalog_collection: str) -> dict[str, str]:
+    def _prepare_env_with_trace_context(self) -> dict[str, str]:
         """
         Prepare environment to trace dask tasks with opentelemetry.
 

--- a/services/staging/rs_server_staging/processors/processor_staging.py
+++ b/services/staging/rs_server_staging/processors/processor_staging.py
@@ -16,6 +16,7 @@
 
 import asyncio  # for handling asynchronous tasks
 import getpass
+import json
 import os
 import re
 import threading
@@ -34,6 +35,7 @@ from dask.distributed import (
 from dask_gateway import Gateway
 from dask_gateway.auth import BasicAuth, JupyterHubAuth
 from fastapi import HTTPException
+from opentelemetry.propagate import inject
 from pygeoapi.process.base import BaseProcessor
 from pygeoapi.process.manager.postgresql import (
     PostgreSQLManager,  # pylint: disable=C0302
@@ -55,6 +57,7 @@ from rs_server_common.s3_storage_handler.s3_storage_handler import (
     S3StorageHandler,
 )
 from rs_server_common.settings import LOCAL_MODE
+from rs_server_common.utils import init_opentelemetry
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils2 import S3Credentials
 from rs_server_staging.processors.authentication import (
@@ -825,15 +828,17 @@ class Staging(
 
     def submit_dask_task(
         self,
+        task_env: dict[str, str],
         client: Client,
         asset: AssetInfo,
         refresh_tokens: dict[str, RefreshTokenData],
         s3_credentials: S3Credentials,
         try_token_refresh: bool = False,
     ) -> Future:
-        """Refresh the access token if needed and submit the streaming task to Dask."""
-        refresh_token = refresh_tokens.get(asset.domain, None)
+        """Submit the streaming task to Dask."""
+
         # refresh the token if needed
+        refresh_token = refresh_tokens.get(asset.domain, None)
         self.logger.debug(
             "Submitting Dask streaming task for job %s; asset=%s, bucket=%s, domain=%s, refresh=%s",
             self.job_id,
@@ -844,8 +849,10 @@ class Staging(
         )
         if refresh_token and try_token_refresh and not update_station_token(refresh_token, self.logger):
             raise RuntimeError(f"Could not retrieve or refresh the token for {asset}")
+
         return client.submit(
             streaming_task,
+            task_env,
             asset,
             refresh_token.config if refresh_token else None,
             TokenAuth(refresh_token.get_access_token()) if refresh_token else None,
@@ -896,6 +903,21 @@ class Staging(
         s3_credentials = authentication.get_s3_credentials(self.request)
         self.logger.debug("Retrieved S3 credentials object for job %s", self.job_id)
 
+        # Prepare environment to trace dask tasks with opentelemetry.
+        task_env = self._prepare_env_with_trace_context(catalog_collection)
+
+        # # TEMP !!
+        # from importlib import reload
+        # import sys
+        # def reload_uploaded():
+        #     reloaded = []
+        #     for module in list(sys.modules.values()):
+        #         if "rs_server" in module.__name__:
+        #             reload(module)
+        #             reloaded.append(module.__name__)
+        #     return f"Reloaded: {reloaded}"
+        # self.logger.debug(json.dumps(client.run(reload_uploaded), indent=2))
+
         # prevent submitting more tasks than necessary.
         # this can occur when the number of tasks that can run in parallel
         # exceeds the actual number of tasks intended for submission.
@@ -912,7 +934,7 @@ class Staging(
         try:
             # initial dataset
             initial_batch_tasks = {
-                self.submit_dask_task(client, next(data_iter), refresh_tokens, s3_credentials)
+                self.submit_dask_task(task_env, client, next(data_iter), refresh_tokens, s3_credentials)
                 for _ in range(max_parallel_tasks)
             }
         except Exception as e:  # pylint: disable=broad-exception-caught
@@ -943,7 +965,7 @@ class Staging(
                 # Submit a new task if available and no errors occurred
                 try:
                     next_asset = next(data_iter)
-                    tasks.add(self.submit_dask_task(client, next_asset, refresh_tokens, s3_credentials, True))
+                    tasks.add(self.submit_dask_task(task_env, client, next_asset, refresh_tokens, s3_credentials, True))
                     self.logger.debug("Queued next asset %s for job %s", next_asset.s3_file, self.job_id)
                 except StopIteration:
                     self.logger.debug("No more Dask tasks to queue for job %s", self.job_id)
@@ -967,6 +989,35 @@ class Staging(
         # Update the subscribers for token refreshment
         self.unsubscribe_refresh_tokens(refresh_tokens)
         self.logger.info("Tasks monitoring finished")
+
+    def _prepare_env_with_trace_context(self, catalog_collection: str) -> dict[str, str]:
+        """
+        Prepare environment to trace dask tasks with opentelemetry.
+
+        https://oneuptime.com/blog/post/2026-02-06-trace-python-subprocess-calls-opentelemetry/view#context-propagation-to-child-processes
+        https://opentelemetry.io/docs/languages/python/propagation/#manual-context-propagation
+
+        Args:
+            catalog_collection (str): The catalog collection name for storing processed features.
+        """
+        env = os.environ.copy()
+
+        # Inject trace context into environment variables
+        carrier: dict[str, str] = {}
+        inject(carrier)
+
+        self.logger.info(f"OpenTelemetry carrier: {carrier!r}")
+
+        # Convert carrier to environment variables
+        if "traceparent" in carrier:
+            env["TRACEPARENT"] = carrier["traceparent"]
+        if "tracestate" in carrier:
+            env["TRACESTATE"] = carrier["tracestate"]
+
+        # Also pass as JSON for scripts that can parse it
+        env["OTEL_TRACE_CONTEXT"] = json.dumps(carrier)
+
+        return env
 
     def dask_cluster_connect(
         self,
@@ -1336,12 +1387,13 @@ class Staging(
         # loop remains responsive while `as_completed` waits for task results.
         self.logger.debug("Starting tasks monitoring thread")
         try:
-            await asyncio.to_thread(
-                self.manage_dask_tasks,
-                dask_client,
-                catalog_collection,
-                refresh_tokens,
-            )
+            with init_opentelemetry.start_span(__name__, f"[{catalog_collection}] manage_dask_tasks"):
+                await asyncio.to_thread(
+                    self.manage_dask_tasks,
+                    dask_client,
+                    catalog_collection,
+                    refresh_tokens,
+                )
         except Exception as e:  # pylint: disable=broad-exception-caught
             self.logger.exception("Task monitoring thread failed for job %s: %s", self.job_id, e)
             self.log_job_execution(JobStatus.failed, 0, f"Error from tasks monitoring thread: {e}")

--- a/services/staging/rs_server_staging/processors/tasks.py
+++ b/services/staging/rs_server_staging/processors/tasks.py
@@ -14,10 +14,12 @@
 
 """Tasks used in processors."""
 
+import json
 import logging
 import os
 from urllib.parse import urlparse
 
+from opentelemetry import context, propagate, trace
 from rs_server_common.authentication.authentication_to_external import (
     ServiceNotFound,
     load_external_auth_config_by_domain,
@@ -34,6 +36,7 @@ from rs_server_common.s3_storage_handler.s3_storage_handler import (
     S3_RETRY_TIMEOUT,
     S3StorageHandler,
 )
+from rs_server_common.utils import init_opentelemetry
 from rs_server_common.utils.logging import Logging
 from rs_server_common.utils.utils2 import S3Credentials
 from rs_server_staging.utils.asset_info import (
@@ -46,13 +49,73 @@ from rs_server_staging.utils.rspy_models import Feature
 logger = Logging.default(__name__)
 
 
-def streaming_task(  # pylint: disable=R0913, R0917
+def restore_context_from_env():
+    """Restore an OpenTelemetry context propagated through environment variables.
+
+    This function reads the ``OTEL_TRACE_CONTEXT`` environment variable,
+    which is expected to contain a JSON-encoded carrier produced by
+    ``opentelemetry.propagate.inject`` in a parent process. The context
+    is extracted and attached to the current execution context so that
+    spans created in this process continue the existing trace.
+    """
+    carrier_json = os.environ.get("OTEL_TRACE_CONTEXT")
+    if not carrier_json:
+        return
+    context.attach(propagate.extract(json.loads(carrier_json)))
+
+
+def streaming_task(task_env: dict[str, str], *args, **kwargs):
+    """
+    This method is run from the dask pod.
+    Init the opentelemetry context before calling the main task method.
+
+    Attributes:
+        task_env: env variables coming from the caller
+    """
+    # Copy env vars from the caller
+    keys = [
+        "OTEL_SERVICE_NAME",
+        "OTEL_TRACE_CONTEXT",
+        "TEMPO_ENDPOINT",
+        "TRACEPARENT",
+        "TRACESTATE",
+    ]
+
+    # Copy our environment variables
+    for key in keys:
+        if value := task_env.get(key):
+            os.environ[key] = value
+    # Copy all OpenTelemetry environment variables
+    for key, value in task_env.items():
+        if key.startswith("OTEL_"):
+            os.environ[key] = value
+
+    # Debug gRPC Connectivity
+    # https://opentelemetry.io/docs/zero-code/python/troubleshooting/#grpc-connectivity
+    # os.environ["GRPC_VERBOSITY"] = "debug"
+    # os.environ["GRPC_TRACE"] = "http,call_error,connectivity_state"
+
+    # Init opentelemetry
+    init_opentelemetry.init_traces(None, os.environ["OTEL_SERVICE_NAME"])
+
+    # Restore OpenTelemetry context
+    restore_context_from_env()
+
+    # Call the main task method from an opentelemetry span
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("streaming_task"):
+        return _streaming_task_otel(*args, **kwargs)
+
+
+def _streaming_task_otel(  # pylint: disable=R0913, R0917
     asset_info: AssetInfo,
     config: ExternalAuthenticationConfig | None,
     auth: str | None,
     s3_credentials: S3Credentials,
 ):
     """
+    This method is run from the dask pod.
+
     Streams a file from a product URL and uploads it to an S3-compatible storage.
 
     This function downloads a file from the specified `product_url` using provided

--- a/services/staging/rs_server_staging/processors/tasks.py
+++ b/services/staging/rs_server_staging/processors/tasks.py
@@ -95,6 +95,10 @@ def streaming_task(task_env: dict[str, str], *args, **kwargs):
     # os.environ["GRPC_VERBOSITY"] = "debug"
     # os.environ["GRPC_TRACE"] = "http,call_error,connectivity_state"
 
+    # Never trace http response body, because it's the downloaded streamed content
+    # and it's probably too big to be traced in otel
+    os.environ["OTEL_PYTHON_REQUESTS_TRACE_BODY"] = "0"
+
     # Init opentelemetry
     init_opentelemetry.init_traces(None, os.environ["OTEL_SERVICE_NAME"])
 

--- a/services/staging/tests/test_processors/test_streaming.py
+++ b/services/staging/tests/test_processors/test_streaming.py
@@ -63,6 +63,7 @@ class TestStreaming:
 
         assert (
             streaming_task(
+                task_env={},
                 asset_info=test_asset_info,
                 config=config,
                 auth=TokenAuth("fake_token"),
@@ -90,6 +91,7 @@ class TestStreaming:
             match=r"Dask task failed to stream file from https://example.com/product.zip to s3://bucket/file.zip",
         ):
             streaming_task(
+                task_env={},
                 asset_info=test_asset_info,
                 config=config,
                 auth=TokenAuth("fake_token"),
@@ -119,6 +121,7 @@ class TestStreaming:
             match=r"Dask task failed to stream file from https://example.com/product.zip to s3://bucket/file.zip",
         ):
             streaming_task(
+                task_env={},
                 asset_info=test_asset_info,
                 config=config,
                 auth=TokenAuth("fake_token"),


### PR DESCRIPTION
https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-1038

This PR allows to trace with opentelemetry the code that is run from inside the dask staging pod. We now have a new span `[<self.staging_user>:<catalog_collection>] staging_dask_tasks"` that contains one sub-span `streaming_task` for each asset to download.
**NOTE**: `manage_dask_tasks` has been renamed `staging_dask_tasks` after this screenshot.
<img width="422" height="369" alt="image" src="https://github.com/user-attachments/assets/fabaacae-066d-4933-b0b7-460b02786ea4" />

Every `streaming_task` span contains an http get request and a s3 post span:
<img width="1424" height="454" alt="image" src="https://github.com/user-attachments/assets/7fb6876b-21d4-4fdd-b214-6d111d20fc5c" />

In grafana/tempo you can filter on your personal staging runs by using your username and collection name: 
<img width="690" height="372" alt="image" src="https://github.com/user-attachments/assets/42ce99bf-2b07-4788-a79f-79b08225c755" />

