### PR TITLE
Map search to ContentDate instead of PublicationDate

### DIFF
--- a/services/common/rs_server_common/stac_api_common.py
+++ b/services/common/rs_server_common/stac_api_common.py
@@ -482,9 +482,9 @@ class MockPgstac(ABC):  # pylint: disable=too-many-instance-attributes
         if datetime:
             try:
                 validate_inputs_format(datetime, raise_errors=True)
-                if self.auxip:
+                if self.auxip or self.prip:
                     stac_params["datetime"] = datetime
-                elif self.cadip or self.prip:
+                elif self.cadip:
                     stac_params["published"] = datetime
             except HTTPException as exception:
                 raise HTTPException(

--- a/services/prip/config/prip_ws_config.template.yaml
+++ b/services/prip/config/prip_ws_config.template.yaml
@@ -182,8 +182,8 @@ template:
           - ModificationDate eq {ModificationDate#to_iso_utc_datetime}
           - OriginDate eq {OriginDate#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
-          - ContentDate/Start eq {Start#to_iso_utc_datetime}
-          - ContentDate/End eq {End#to_iso_utc_datetime}
+          - (ContentDate/Start gt {Start#to_iso_utc_datetime} or ContentDate/Start eq {Start#to_iso_utc_datetime})
+          - (ContentDate/End lt {End#to_iso_utc_datetime} or ContentDate/End eq {End#to_iso_utc_datetime})
           # ---- ContentLength (numeric) ----
           - ContentLength eq {ContentLength#to_int}
           - ContentLength gt {ContentLengthMin#to_int}
@@ -217,8 +217,6 @@ template:
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'datatakeID' and att/OData.CSC.StringAttribute/Value eq '{datatakeID}')
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'coordinates' and att/OData.CSC.StringAttribute/Value eq {coordinates})
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'instrumentConfigurationID' and att/OData.CSC.StringAttribute/Value eq '{instrumentConfigurationID}')
-          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'beginningDateTime' and att/OData.CSC.StringAttribute/Value eq '{Start#to_iso_utc_datetime}')
-          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'endingDateTime' and att/OData.CSC.StringAttribute/Value eq '{End#to_iso_utc_datetime}')
           - "{t_before}"
           - "{t_after}"
           - "{t_meets}"

--- a/services/prip/config/prip_ws_config.yaml
+++ b/services/prip/config/prip_ws_config.yaml
@@ -186,8 +186,9 @@ s1a:
           - ModificationDate eq {ModificationDate#to_iso_utc_datetime}
           - OriginDate eq {OriginDate#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
-          - ContentDate/Start eq {Start#to_iso_utc_datetime}
-          - ContentDate/End eq {End#to_iso_utc_datetime}
+          - (ContentDate/Start gt {Start#to_iso_utc_datetime} or ContentDate/Start
+            eq {Start#to_iso_utc_datetime})
+          - (ContentDate/End lt {End#to_iso_utc_datetime} or ContentDate/End eq {End#to_iso_utc_datetime})
           - ContentLength eq {ContentLength#to_int}
           - ContentLength gt {ContentLengthMin#to_int}
           - ContentLength lt {ContentLengthMax#to_int}
@@ -234,10 +235,6 @@ s1a:
             and att/OData.CSC.StringAttribute/Value eq {coordinates})
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'instrumentConfigurationID'
             and att/OData.CSC.StringAttribute/Value eq '{instrumentConfigurationID}')
-          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'beginningDateTime'
-            and att/OData.CSC.StringAttribute/Value eq '{Start#to_iso_utc_datetime}')
-          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'endingDateTime'
-            and att/OData.CSC.StringAttribute/Value eq '{End#to_iso_utc_datetime}')
           - '{t_before}'
           - '{t_after}'
           - '{t_meets}'
@@ -451,8 +448,9 @@ s2b:
           - ModificationDate eq {ModificationDate#to_iso_utc_datetime}
           - OriginDate eq {OriginDate#to_iso_utc_datetime}
           - ContentDate/Start eq {DatetimeStart#to_iso_utc_datetime}
-          - ContentDate/Start eq {Start#to_iso_utc_datetime}
-          - ContentDate/End eq {End#to_iso_utc_datetime}
+          - (ContentDate/Start gt {Start#to_iso_utc_datetime} or ContentDate/Start
+            eq {Start#to_iso_utc_datetime})
+          - (ContentDate/End lt {End#to_iso_utc_datetime} or ContentDate/End eq {End#to_iso_utc_datetime})
           - ContentLength eq {ContentLength#to_int}
           - ContentLength gt {ContentLengthMin#to_int}
           - ContentLength lt {ContentLengthMax#to_int}
@@ -499,10 +497,6 @@ s2b:
             and att/OData.CSC.StringAttribute/Value eq {coordinates})
           - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'instrumentConfigurationID'
             and att/OData.CSC.StringAttribute/Value eq '{instrumentConfigurationID}')
-          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'beginningDateTime'
-            and att/OData.CSC.StringAttribute/Value eq '{Start#to_iso_utc_datetime}')
-          - Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'endingDateTime'
-            and att/OData.CSC.StringAttribute/Value eq '{End#to_iso_utc_datetime}')
           - '{t_before}'
           - '{t_after}'
           - '{t_meets}'

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -2462,7 +2462,7 @@ def test_search_parameters(
         (
             {"collections": "S1A_L0_IW_RAW", "datetime": "2022-06-26T06:30:34.558Z"},
             "http://127.0.0.1:5000/Products?"
-            "$filter=PublicationDate eq 2022-06-26T06:30:34.558Z and "
+            "$filter=ContentDate/Start eq 2022-06-26T06:30:34.558Z and "
             "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' "
             "and att/OData.CSC.StringAttribute/Value eq 'IW_RAW__0N')"
             "&$orderby=PublicationDate desc&$top=10&$skip=0&$expand=Attributes",
@@ -2470,7 +2470,7 @@ def test_search_parameters(
         (
             {"collections": "S1A_L0_IW_RAW", "datetime": "2022-06-26T06:30:34.558Z", "sortby": "+published"},
             "http://127.0.0.1:5000/Products?"
-            "$filter=PublicationDate eq 2022-06-26T06:30:34.558Z and "
+            "$filter=ContentDate/Start eq 2022-06-26T06:30:34.558Z and "
             "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' "
             "and att/OData.CSC.StringAttribute/Value eq 'IW_RAW__0N')"
             "&$orderby=PublicationDate asc&$top=10&$skip=0&$expand=Attributes",
@@ -2478,10 +2478,10 @@ def test_search_parameters(
         (
             {"collections": "S1A_L0_IW_RAW", "datetime": "2022-06-26T06:30:34.558Z/2023-06-26T06:30:34.558Z"},
             "http://127.0.0.1:5000/Products?"
-            "$filter=(PublicationDate gt 2022-06-26T06:30:34.558Z or "
-            "PublicationDate eq 2022-06-26T06:30:34.558Z) and "
-            "(PublicationDate lt 2023-06-26T06:30:34.558Z or "
-            "PublicationDate eq 2023-06-26T06:30:34.558Z) and "
+            "$filter=(ContentDate/Start gt 2022-06-26T06:30:34.558Z or "
+            "ContentDate/Start eq 2022-06-26T06:30:34.558Z) and "
+            "(ContentDate/End lt 2023-06-26T06:30:34.558Z or "
+            "ContentDate/End eq 2023-06-26T06:30:34.558Z) and "
             "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' "
             "and att/OData.CSC.StringAttribute/Value eq 'IW_RAW__0N')"
             "&$orderby=PublicationDate desc&$top=10&$skip=0&$expand=Attributes",
@@ -2500,7 +2500,7 @@ def test_search_parameters(
         (
             {"collections": "S1A_L0_IW_RAW", "datetime": "2022-06-26T06:30:34.558Z"},
             "http://127.0.0.1:5000/Products?"
-            "$filter=PublicationDate eq 2022-06-26T06:30:34.558Z and "
+            "$filter=ContentDate/Start eq 2022-06-26T06:30:34.558Z and "
             "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' "
             "and att/OData.CSC.StringAttribute/Value eq 'IW_RAW__0N')"
             "&$orderby=PublicationDate desc&$top=10&$skip=0&$expand=Attributes",
@@ -2508,8 +2508,9 @@ def test_search_parameters(
         (
             {"collections": "S1A_L0_IW_RAW", "datetime": "2022-06-26T06:30:34.558Z/2023-06-26T06:30:34.558Z"},
             "http://127.0.0.1:5000/Products?"
-            "$filter=(PublicationDate gt 2022-06-26T06:30:34.558Z or PublicationDate eq 2022-06-26T06:30:34.558Z) and "
-            "(PublicationDate lt 2023-06-26T06:30:34.558Z or PublicationDate eq 2023-06-26T06:30:34.558Z) and "
+            "$filter=(ContentDate/Start gt 2022-06-26T06:30:34.558Z or "
+            "ContentDate/Start eq 2022-06-26T06:30:34.558Z) and "
+            "(ContentDate/End lt 2023-06-26T06:30:34.558Z or ContentDate/End eq 2023-06-26T06:30:34.558Z) and "
             "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' "
             "and att/OData.CSC.StringAttribute/Value eq 'IW_RAW__0N')"
             "&$orderby=PublicationDate desc&$top=10&$skip=0&$expand=Attributes",
@@ -2678,13 +2679,11 @@ def test_get_search_parameters_prip(client, mocker, prip_response, collection_pa
                 "sortby": [{"field": "published", "direction": "desc"}],
             },
             "http://127.0.0.1:5000/Products?"
-            "$filter=ContentDate/Start eq 2020-06-26T06:30:34.558Z and ContentDate/End eq 2023-06-26T06:30:34.558Z "
+            "$filter=(ContentDate/Start gt 2020-06-26T06:30:34.558Z or "
+            "ContentDate/Start eq 2020-06-26T06:30:34.558Z) and "
+            "(ContentDate/End lt 2023-06-26T06:30:34.558Z or ContentDate/End eq 2023-06-26T06:30:34.558Z) "
             "and Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'productType' and "
-            "att/OData.CSC.StringAttribute/Value eq 'IW_RAW__0N') and "
-            "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'beginningDateTime' and "
-            "att/OData.CSC.StringAttribute/Value eq '2020-06-26T06:30:34.558Z') and "
-            "Attributes/OData.CSC.StringAttribute/any(att:att/Name eq 'endingDateTime' "
-            "and att/OData.CSC.StringAttribute/Value eq '2023-06-26T06:30:34.558Z')"
+            "att/OData.CSC.StringAttribute/Value eq 'IW_RAW__0N')"
             "&$orderby=PublicationDate desc&$top=10&$skip=0&$expand=Attributes",
         ),
         (


### PR DESCRIPTION
feat-rspy1124-prip-publicationDate-contentdate
When searching with STAC datetime parameter, the OData search should be performed as per PRIP STAC/OData mapping on the ContentDate/Start property.